### PR TITLE
Fix memory errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/CertiVox/MIRACL.git
 [submodule "src/abycore/ot/external"]
 	path = src/abycore/ot/external
-	url = git://github.com/encryptogroup/OTExtension.git
+	url = git://github.com/schoppmp/OTExtension.git

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -521,8 +521,8 @@ BOOL ABYParty::ABYPartyListen() {
 	bool success = Listen(m_cAddress, m_nPort, tempsocks, m_vSockets.size(), (uint32_t) m_eRole);
 	for(uint32_t i = 0; i < m_vSockets.size(); i++) {
 		m_vSockets[i] = tempsocks[1][i];
+		delete tempsocks[0][i];
 	}
-	tempsocks[0][0]->Close();
 	return success;
 }
 

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -137,6 +137,8 @@ void ABYParty::Cleanup() {
 
 	delete m_tComm->snd_std;
 	delete m_tComm->snd_inv;
+	delete m_tComm->rcv_std;
+	delete m_tComm->rcv_inv;
 
 	free(m_tComm);
 
@@ -631,4 +633,3 @@ void ABYParty::CPartyWorkerThread::ThreadMain() {
 		m_pCallback->ThreadNotifyTaskDone(bSuccess);
 	}
 }
-

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -352,6 +352,7 @@ BOOL ABYParty::EvaluateCircuit() {
 		cout << "Done with online phase; synchronizing "<< endl;
 #endif
 	m_tPartyChan->synchronize_end();
+	delete m_tPartyChan;
 
 #ifdef BENCHONLINEPHASE
 	cout << "Online time is distributed as follows: " << endl;

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -143,6 +143,7 @@ void ABYParty::Cleanup() {
 	for (uint32_t i = 0; i < m_vSockets.size(); i++) {
 		m_vSockets[i]->Close();
 	}
+	delete m_cCrypt;
 }
 
 CBitVector ABYParty::ExecCircuit() {
@@ -401,13 +402,7 @@ BOOL ABYParty::ThreadSendValues() {
 		m_tPartyChan->send(snd_buf_total, snd_buf_size_total);
 	}
 
-	for (uint32_t j = 0; j < m_vSharings.size(); j++) {
-		sendbuf[j].clear();
-		sndbytes[j].clear();
-	}
-	sendbuf.clear();
-	sndbytes.clear();
-	//free(snd_buf_total);
+	free(snd_buf_total);
 
 	return true;
 }

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -142,6 +142,7 @@ void ABYParty::Cleanup() {
 
 	for (uint32_t i = 0; i < m_vSockets.size(); i++) {
 		m_vSockets[i]->Close();
+		delete m_vSockets[i];
 	}
 	delete m_cCrypt;
 }

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -131,7 +131,6 @@ void ABYParty::Cleanup() {
 	for (uint32_t i = 0; i < m_nHelperThreads; i++) {
 		m_vThreads[i]->PutJob(e_Party_Stop);
 		m_vThreads[i]->Wait();
-		m_vThreads[i]->Kill();
 		delete m_vThreads[i];
 	}
 

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -115,10 +115,15 @@ BOOL ABYParty::Init() {
 }
 
 void ABYParty::Cleanup() {
-	Reset();
 	if (m_pSetup)
 		delete m_pSetup;
 
+	// free any gates that are still instantiated
+	for(size_t i = 0; i < m_pCircuit->GetGateHead(); i++) {
+		if(m_pGates[i].instantiated) {
+			m_vSharings[0]->FreeGate(&m_pGates[i]);
+		}
+	}
 	for(uint32_t i = 0; i < S_LAST; i++) {
 		if(m_vSharings[i]) {
 			delete m_vSharings[i];

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -87,7 +87,6 @@ ABYParty::ABYParty(e_role pid, char* addr, uint16_t port, seclvl seclvl, uint32_
 }
 
 ABYParty::~ABYParty() {
-
 	m_vSharings[S_BOOL]->PreCompFileDelete();
 	Cleanup();
 }

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -69,6 +69,11 @@ BOOL ABYSetup::Init() {
 }
 
 void ABYSetup::Cleanup() {
+	for(size_t i = 0; i < m_vThreads.size(); i++) {
+		m_vThreads[i]->PutJob(e_Stop);
+		m_vThreads[i]->Wait();
+		delete m_vThreads[i];
+	}
 	if(m_tSetupChan) {
 		m_tSetupChan->synchronize_end();
 		delete m_tSetupChan;
@@ -89,7 +94,6 @@ void ABYSetup::Cleanup() {
 		delete kk_ot_sender;
 	}
 #endif
-
 
 }
 

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -214,7 +214,9 @@ BOOL ABYSetup::ThreadRunIKNPSnd(uint32_t exec) {
 		cout << "X1: ";
 		task->pval.sndval.X1->PrintHex();
 #endif
-		delete task->mskfct;
+		if(task->delete_mskfct)	{
+			delete task->mskfct;
+		}
 		free(task);
 	}
 	m_vIKNPOTTasks[inverse].resize(0);
@@ -245,7 +247,9 @@ BOOL ABYSetup::ThreadRunIKNPRcv(uint32_t exec) {
 		cout << "R: ";
 		task->pval.rcvval.R->PrintHex();
 #endif
-		delete task->mskfct;
+		if(task->delete_mskfct)	{
+			delete task->mskfct;
+		}
 		free(task);
 	}
 	m_vIKNPOTTasks[inverse].resize(0);
@@ -282,7 +286,9 @@ BOOL ABYSetup::ThreadRunKKSnd(uint32_t exec) {
 			X[j]->PrintHex();
 		}
 #endif
-		delete task->mskfct;
+		if(task->delete_mskfct)	{
+			delete task->mskfct;
+		}
 		free(task);
 	}
 	m_vKKOTTasks[inverse].resize(0);
@@ -312,7 +318,9 @@ BOOL ABYSetup::ThreadRunKKRcv(uint32_t exec) {
 		cout << "R: ";
 		task->pval.rcvval.R->PrintHex();
 #endif
-		delete task->mskfct;
+		if(task->delete_mskfct)	{
+			delete task->mskfct;
+		}
 		free(task);
 	}
 	m_vKKOTTasks[inverse].resize(0);

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -214,8 +214,10 @@ BOOL ABYSetup::ThreadRunIKNPSnd(uint32_t exec) {
 		cout << "X1: ";
 		task->pval.sndval.X1->PrintHex();
 #endif
+		free(task);
 	}
 	m_vIKNPOTTasks[inverse].resize(0);
+	free(X);
 	return success;
 }
 
@@ -242,6 +244,7 @@ BOOL ABYSetup::ThreadRunIKNPRcv(uint32_t exec) {
 		cout << "R: ";
 		task->pval.rcvval.R->PrintHex();
 #endif
+		free(task);
 	}
 	m_vIKNPOTTasks[inverse].resize(0);
 	return success;
@@ -256,10 +259,9 @@ BOOL ABYSetup::ThreadRunKKSnd(uint32_t exec) {
 
 	for (uint32_t i = 0; i < m_vKKOTTasks[inverse].size(); i++) {
 		KK_OTTask* task = m_vKKOTTasks[inverse][i];
-		CBitVector** X = (CBitVector**) malloc(sizeof(CBitVector*) * task->nsndvals);
 
 		uint32_t numOTs = task->numOTs;
-		X = task->pval.sndval.X;
+		CBitVector** X = task->pval.sndval.X;
 
 		/*cout << "Address of X = " << (uint64_t) X << endl;
 		for(uint32_t j = 0; j < task->nsndvals; j++) {
@@ -277,8 +279,8 @@ BOOL ABYSetup::ThreadRunKKSnd(uint32_t exec) {
 			cout << "X" << j << ": ";
 			X[j]->PrintHex();
 		}
-
 #endif
+		free(task);
 	}
 	m_vKKOTTasks[inverse].resize(0);
 	return success;
@@ -307,6 +309,7 @@ BOOL ABYSetup::ThreadRunKKRcv(uint32_t exec) {
 		cout << "R: ";
 		task->pval.rcvval.R->PrintHex();
 #endif
+		free(task);
 	}
 	m_vKKOTTasks[inverse].resize(0);
 	return success;

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -74,7 +74,7 @@ void ABYSetup::Cleanup() {
 		m_tSetupChan->synchronize_end();
 		delete m_tSetupChan;
 	}
-/*	if(iknp_ot_sender) {
+	if(iknp_ot_sender) {
 		delete iknp_ot_sender;
 	}
 	if(iknp_ot_receiver) {
@@ -83,14 +83,14 @@ void ABYSetup::Cleanup() {
 
 #ifdef USE_KK_OT
 	//FIXME: deleting kk_ot_receiver or sender causes a SegFault in AES with Yao
-	if(kk_ot_receiver) {	
+	if(kk_ot_receiver) {
 		delete kk_ot_receiver;
 	}
 	if(kk_ot_sender) {
 		delete kk_ot_sender;
 	}
 #endif
-*/
+
 
 }
 
@@ -519,4 +519,3 @@ void ABYSetup::Reset() {
 		m_vKKOTTasks[i].clear();
 	}
 }
-

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -69,7 +69,6 @@ BOOL ABYSetup::Init() {
 }
 
 void ABYSetup::Cleanup() {
-
 	if(m_tSetupChan) {
 		m_tSetupChan->synchronize_end();
 		delete m_tSetupChan;

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -214,6 +214,7 @@ BOOL ABYSetup::ThreadRunIKNPSnd(uint32_t exec) {
 		cout << "X1: ";
 		task->pval.sndval.X1->PrintHex();
 #endif
+		delete task->mskfct;
 		free(task);
 	}
 	m_vIKNPOTTasks[inverse].resize(0);
@@ -244,6 +245,7 @@ BOOL ABYSetup::ThreadRunIKNPRcv(uint32_t exec) {
 		cout << "R: ";
 		task->pval.rcvval.R->PrintHex();
 #endif
+		delete task->mskfct;
 		free(task);
 	}
 	m_vIKNPOTTasks[inverse].resize(0);
@@ -280,6 +282,7 @@ BOOL ABYSetup::ThreadRunKKSnd(uint32_t exec) {
 			X[j]->PrintHex();
 		}
 #endif
+		delete task->mskfct;
 		free(task);
 	}
 	m_vKKOTTasks[inverse].resize(0);
@@ -309,6 +312,7 @@ BOOL ABYSetup::ThreadRunKKRcv(uint32_t exec) {
 		cout << "R: ";
 		task->pval.rcvval.R->PrintHex();
 #endif
+		delete task->mskfct;
 		free(task);
 	}
 	m_vKKOTTasks[inverse].resize(0);
@@ -344,7 +348,7 @@ BOOL ABYSetup::ThreadRunPaillierMTGen(uint32_t threadid) {
 			m_cPaillierMTGen->preCompBench(ptask->A->GetArr() + roleoffset, ptask->B->GetArr() + roleoffset, ptask->C->GetArr() + roleoffset, ptask->A->GetArr() + mystartpos,
 					ptask->B->GetArr() + mystartpos, ptask->C->GetArr() + mystartpos, mynummts, djnchan);
 		}
-
+		free(ptask);
 	}
 	djnchan->synchronize_end();
 	delete djnchan;
@@ -383,6 +387,7 @@ BOOL ABYSetup::ThreadRunDGKMTGen(uint32_t threadid) {
 			m_cDGKMTGen[i]->preCompBench(ptask->A->GetArr() + roleoffset, ptask->B->GetArr() + roleoffset, ptask->C->GetArr() + roleoffset, ptask->A->GetArr() + mystartpos,
 					ptask->B->GetArr() + mystartpos, ptask->C->GetArr() + mystartpos, mynummts, dgkchan);
 		}
+		free(ptask);
 	}
 	dgkchan->synchronize_end();
 	delete dgkchan;

--- a/src/abycore/aby/abysetup.h
+++ b/src/abycore/aby/abysetup.h
@@ -86,6 +86,7 @@ struct IKNP_OTTask {
 	uint32_t numOTs;	//number of OTs that are performed
 	uint32_t bitlen; //bitlen in the OTs
 	MaskingFunction* mskfct; //the masking function used
+	BOOL delete_mskfct; // whether or not to delete mskfct when the task is done
 	IKNPPartyValues pval;   //contains the sender and receivers input and output
 };
 
@@ -97,6 +98,7 @@ struct KK_OTTask {
 	uint32_t numOTs;	//number of OTs that are performed
 	uint32_t bitlen; //bitlen in the OTs
 	MaskingFunction* mskfct; //the masking function used
+	BOOL delete_mskfct; // whether or not to delete mskfct when the task is done
 	KKPartyValues pval;   //contains the sender and receivers input and output
 };
 
@@ -232,4 +234,3 @@ private:
 };
 
 #endif //__ABYSETUP_H__
-

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -463,8 +463,8 @@ uint32_t ABYCircuit::PutTruthTableGate(vector<uint32_t> in, uint32_t rounds, uin
 	uint32_t tt_len = 1<<(in.size());
 
 	gate->gs.tt.noutputs = out_bits;
-	gate->gs.tt.table = (uint64_t*) malloc(pad_to_multiple(tt_len, sizeof(UGATE_T)) * out_bits);
-	memcpy(gate->gs.tt.table, truth_table, pad_to_multiple(tt_len, sizeof(UGATE_T)) * out_bits);
+	gate->gs.tt.table = (uint64_t*) malloc(bits_in_bytes(pad_to_multiple(tt_len, sizeof(UGATE_T)) * out_bits));
+	memcpy(gate->gs.tt.table, truth_table, bits_in_bytes(pad_to_multiple(tt_len, sizeof(UGATE_T)) * out_bits));
 
 	gate->nrounds = rounds;
 

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -799,10 +799,11 @@ uint32_t FindBitLenPositionInVec(uint32_t bitlen, non_lin_vec_ctx* list, uint32_
 }
 
 void ABYCircuit::Reset() {
-	//FIXME: causes segfault in Boolean sharing if only one party gets output, fix!
-	for (uint32_t i = 0; i < m_nNextFreeGate; i++) {
-		if (m_pGates[i].type == G_OUT)
+	// free any gates that are still instantiated
+	for(size_t i = 0; i < GetGateHead(); i++) {
+		if(m_pGates[i].instantiated) {
 			free(m_pGates[i].gs.val);
+		}
 	}
 	memset(m_pGates, 0, sizeof(GATE) * m_nMaxGates);
 	m_nNextFreeGate = 0;

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -19,7 +19,7 @@
 #include "abycircuit.h"
 
 void ABYCircuit::Cleanup() {
-	//TODO
+	Reset();
 	free(m_pGates);
 }
 

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -799,12 +799,6 @@ uint32_t FindBitLenPositionInVec(uint32_t bitlen, non_lin_vec_ctx* list, uint32_
 }
 
 void ABYCircuit::Reset() {
-	// free any gates that are still instantiated
-	for(size_t i = 0; i < GetGateHead(); i++) {
-		if(m_pGates[i].instantiated) {
-			free(m_pGates[i].gs.val);
-		}
-	}
 	memset(m_pGates, 0, sizeof(GATE) * m_nMaxGates);
 	m_nNextFreeGate = 0;
 	m_nMaxVectorSize = 1;

--- a/src/abycore/circuit/abycircuit.h
+++ b/src/abycore/circuit/abycircuit.h
@@ -183,6 +183,7 @@ public:
 	GATE* Gates() {
 		return m_pGates;
 	}
+
 	uint32_t PutPrimitiveGate(e_gatetype type, uint32_t inleft, uint32_t inright, uint32_t rounds);
 	uint32_t PutNonLinearVectorGate(e_gatetype type, uint32_t choiceinput, uint32_t vectorinput, uint32_t rounds);
 	uint32_t PutCombinerGate(vector<uint32_t> input);

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -873,6 +873,7 @@ void ArithSharing<T>::UsedGate(uint32_t gateid) {
 	//If the gate is needed in another subsequent gate, delete it
 	if (!m_pGates[gateid].nused) {
 		free(((T*) m_pGates[gateid].gs.val));
+		m_pGates[gateid].instantiated = false;
 	}
 }
 

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -95,6 +95,7 @@ void ArithSharing<T>::PrepareSetupPhase(ABYSetup* setup) {
 				task->rec_flavor = Rec_OT;
 				task->numOTs = m_nMTs * m_nTypeBitLen;
 				task->mskfct = fMaskFct;
+				task->delete_mskfct = (i == 0 ? TRUE : FALSE);
 				if ((m_eRole ^ i) == SERVER) {
 					task->pval.sndval.X0 = &(m_vC[0]);
 					task->pval.sndval.X1 = &(m_vC[0]);
@@ -120,6 +121,7 @@ void ArithSharing<T>::PrepareSetupPhase(ABYSetup* setup) {
 		task->rec_flavor = Rec_OT;
 		task->numOTs = m_nNumCONVs * m_nTypeBitLen;
 		task->mskfct = fXORMaskFct;
+		task->delete_mskfct = TRUE;
 		if ((m_eRole) == SERVER) {
 			m_vConversionMasks[0].Create(m_nNumCONVs * m_nTypeBitLen, m_nTypeBitLen);
 			m_vConversionMasks[1].Create(m_nNumCONVs * m_nTypeBitLen, m_nTypeBitLen);

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -34,7 +34,7 @@ void ArithSharing<T>::Init() {
 	m_nConvShareIdx = 0;
 	m_nConvShareSndCtr = 0;
 	m_nConvShareRcvCtr = 0;
-	
+
 	m_nInputShareSndCtr = 0;
 	m_nOutputShareSndCtr = 0;
 	m_nInputShareRcvCtr = 0;
@@ -77,7 +77,6 @@ void ArithSharing<T>::PrepareSetupPhase(ABYSetup* setup) {
 
 	InitMTs();
 
-	ArithMTMasking<T> *fMaskFct = new ArithMTMasking<T>(1, &(m_vB[0])); //TODO to implement the vector multiplication change first argument
 	if (m_nMTs > 0) {
 		if (m_eMTGenAlg == MT_PAILLIER || m_eMTGenAlg == MT_DGK) {
 			PKMTGenVals* pgentask = (PKMTGenVals*) malloc(sizeof(PKMTGenVals));
@@ -88,6 +87,7 @@ void ArithSharing<T>::PrepareSetupPhase(ABYSetup* setup) {
 			pgentask->sharebitlen = m_nTypeBitLen;
 			setup->AddPKMTGenTask(pgentask);
 		} else {
+			ArithMTMasking<T> *fMaskFct = new ArithMTMasking<T>(1, &(m_vB[0])); //TODO to implement the vector multiplication change first argument
 			for (uint32_t i = 0; i < 2; i++) {
 				IKNP_OTTask* task = (IKNP_OTTask*) malloc(sizeof(IKNP_OTTask));
 				task->bitlen = m_nTypeBitLen;
@@ -1116,4 +1116,3 @@ template class ArithSharing<UINT8_T> ;
 template class ArithSharing<UINT16_T> ;
 template class ArithSharing<UINT32_T> ;
 template class ArithSharing<UINT64_T> ;
-

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -87,15 +87,15 @@ void ArithSharing<T>::PrepareSetupPhase(ABYSetup* setup) {
 			pgentask->sharebitlen = m_nTypeBitLen;
 			setup->AddPKMTGenTask(pgentask);
 		} else {
-			ArithMTMasking<T> *fMaskFct = new ArithMTMasking<T>(1, &(m_vB[0])); //TODO to implement the vector multiplication change first argument
 			for (uint32_t i = 0; i < 2; i++) {
+				ArithMTMasking<T> *fMaskFct = new ArithMTMasking<T>(1, &(m_vB[0])); //TODO to implement the vector multiplication change first argument
 				IKNP_OTTask* task = (IKNP_OTTask*) malloc(sizeof(IKNP_OTTask));
 				task->bitlen = m_nTypeBitLen;
 				task->snd_flavor = Snd_C_OT;
 				task->rec_flavor = Rec_OT;
 				task->numOTs = m_nMTs * m_nTypeBitLen;
 				task->mskfct = fMaskFct;
-				task->delete_mskfct = (i == 0 ? TRUE : FALSE);
+				task->delete_mskfct = TRUE;
 				if ((m_eRole ^ i) == SERVER) {
 					task->pval.sndval.X0 = &(m_vC[0]);
 					task->pval.sndval.X1 = &(m_vC[0]);

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -1076,7 +1076,7 @@ void ArithSharing<T>::Reset() {
 	m_nOutputShareRcvCtr = 0;
 
 	//TODO if vector multiplication triples are implemented, make size variable
-	for (uint32_t i = 0; i < 1; i++) {
+	for (uint32_t i = 0; i < m_vA.size(); i++) {
 		m_vA[i].delCBitVector();
 		m_vB[i].delCBitVector();
 		m_vS[i].delCBitVector();

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -867,17 +867,6 @@ void ArithSharing<T>::InstantiateGate(GATE* gate) {
 }
 
 template<typename T>
-void ArithSharing<T>::UsedGate(uint32_t gateid) {
-	//Decrease the number of further uses of the gate
-	m_pGates[gateid].nused--;
-	//If the gate is needed in another subsequent gate, delete it
-	if (!m_pGates[gateid].nused) {
-		free(((T*) m_pGates[gateid].gs.val));
-		m_pGates[gateid].instantiated = false;
-	}
-}
-
-template<typename T>
 void ArithSharing<T>::EvaluateSIMDGate(uint32_t gateid) {
 	GATE* gate = m_pGates + gateid;
 	uint32_t vsize = gate->nvals;

--- a/src/abycore/sharing/arithsharing.h
+++ b/src/abycore/sharing/arithsharing.h
@@ -62,9 +62,6 @@ public:
 	}
 
 	void InstantiateGate(GATE* gate);
-	// void UsedGate(uint32_t gateid) {
-	// 	UsedGate(gateid);
-	// }
 
 	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
 	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);

--- a/src/abycore/sharing/arithsharing.h
+++ b/src/abycore/sharing/arithsharing.h
@@ -62,7 +62,9 @@ public:
 	}
 
 	void InstantiateGate(GATE* gate);
-	void UsedGate(uint32_t gateid);
+	// void UsedGate(uint32_t gateid) {
+	// 	UsedGate(gateid);
+	// }
 
 	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
 	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
@@ -91,18 +93,18 @@ public:
 
 	void PrintPerformanceStatistics();
 	//ENDS HERE...
-	/** 
+	/**
 	 Evaluating SIMD Gate.
 	 \param 	gateid 	Identifier of the gate to be evaluated.
 	 */
 	void EvaluateSIMDGate(uint32_t gateid);
 
-	/** 
+	/**
 	 Evaluating Inversion Gate.
 	 \param 	gate 	Object of the gate to be evaluated.
 	 */
 	void EvaluateINVGate(GATE* gate);
-	/** 
+	/**
 	 Evaluating Conversion Gate.
 	 \param 	gate 	Object of the gate to be evaluated.
 	 */
@@ -159,12 +161,12 @@ private:
 	uint32_t m_nConvShareIdx; //the global
 	uint32_t m_nConvShareSndCtr; //counts for each round
 	uint32_t m_nConvShareRcvCtr;
-	/** 
+	/**
 	 Share Values
 	 \param 	gate 	Object of class Gate
 	 */
 	void ShareValues(GATE* gate);
-	/** 
+	/**
 	 Reconstruct Values
 	 \param 	gate 	Object of class Gate
 	 */

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -1819,4 +1819,3 @@ BOOL BoolSharing::isCircuitSizeLessThanOrEqualWithValueFromFile(char *filename, 
 	fclose(fp);
 	return TRUE;
 }
-

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -1332,6 +1332,9 @@ void BoolSharing::EvaluateSIMDGate(uint32_t gateid) {
 				UsedGate(input[i + k * GATE_T_BITS]);
 			}
 		}*/
+		for(uint32_t i = 0; i < nparents; i++) {
+			UsedGate(input[i]);
+		}
 
 		free(input);
 	} else if (gate->type == G_SPLIT) {
@@ -1543,8 +1546,6 @@ void BoolSharing::Reset() {
 		m_vMTStartIdx[i] = 0;
 	for (uint32_t i = 0; i < m_vMTIdx.size(); i++)
 		m_vMTIdx[i] = 0;
-	for (uint32_t i = 0; i < m_vANDGates.size(); i++)
-		m_vANDGates.clear();
 	m_vANDGates.clear();
 
 	m_vInputShareGates.clear();

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -153,6 +153,7 @@ void BoolSharing::PrepareSetupPhaseMTs(ABYSetup* setup) {
 			task->nsndvals = 4;
 			task->numOTs = ceil_divide(m_nNumMTs[0], 2);
 			task->mskfct = fMaskFct;
+			task->delete_mskfct = (i == 0 ? TRUE : FALSE);
 			if ((m_eRole ^ j) == SERVER) {
 				task->pval.sndval.X = m_vKKS.data();
 			} else {
@@ -320,6 +321,7 @@ void BoolSharing::PrepareSetupPhaseOPLUT(ABYSetup* setup) {
 
 		fMaskFct = new XORMasking(task->bitlen);
 		task->mskfct = fMaskFct;
+		task->delete_mskfct = TRUE;
 		if (m_eRole == SERVER) {
 			//cout << "I assigned sender" << endl;
 			task->pval.sndval.X = it->second->rot_OT_vals;

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -755,6 +755,7 @@ inline void BoolSharing::EvaluateCONVGate(uint32_t gateid) {
 	uint32_t parentid = gate->ingates.inputs.parents[0];
 	if (m_pGates[parentid].context == S_ARITH)
 		cerr << "can't convert from arithmetic representation directly into Boolean" << endl;
+	assert(m_pGates[parentid].context == S_YAO);
 	InstantiateGate(gate);
 
 	memset(gate->gs.val, 0, ceil_divide(gate->nvals, 8));
@@ -1276,6 +1277,11 @@ inline void BoolSharing::UsedGate(uint32_t gateid) {
 	//If the gate is needed in another subsequent gate, delete it
 	if (!m_pGates[gateid].nused) {
 		free(m_pGates[gateid].gs.val);
+		if(m_eRole == SERVER && m_pGates[gateid].context == S_YAO) {
+			// free additional field of Y2B conversion gates
+			free(m_pGates[gateid].gs.yinput.pi);
+		}
+		m_pGates[gateid].instantiated = false;
 	}
 }
 

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -1525,17 +1525,6 @@ void BoolSharing::Reset() {
 
 	m_nNumANDSizes = 0;
 
-	// free any gates that are still instantiated
-	// TODO: This should be done when evaluating the circuit using UsedGate()
-	// however, there seem to be cases where this doesn't work, so this loop
-	// cleans up the rest.
-	for(size_t i = 0; i < m_pCircuit->GetGateHead(); i++) {
-		if(m_pGates[i].instantiated && m_pGates[i].context == S_BOOL) {
-			free(m_pGates[i].gs.val);
-			m_pGates[i].instantiated = false;
-		}
-	}
-
 	for (uint32_t i = 0; i < m_nNumMTs.size(); i++) {
 		m_nNumMTs[i] = 0;
 	}

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -772,6 +772,7 @@ inline void BoolSharing::EvaluateCONVGate(uint32_t gateid) {
 #endif
 
 	UsedGate(parentid);
+	free(gate->ingates.inputs.parents);
 }
 
 inline void BoolSharing::ReconstructValue(uint32_t gateid) {

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -143,8 +143,6 @@ void BoolSharing::PrepareSetupPhaseMTs(ABYSetup* setup) {
 	if((GetPreCompPhaseValue() != ePreCompRead)&&(GetPreCompPhaseValue() != ePreCompRAMRead)) {
 
 #ifdef USE_KK_OT_FOR_MT
-		fMaskFct = new XORMasking(m_vANDs[0].bitlen);
-
 		for (uint32_t j = 0; j < 2; j++) {
 			KK_OTTask* task = (KK_OTTask*) malloc(sizeof(KK_OTTask));
 			task->bitlen = m_vANDs[0].bitlen;
@@ -152,8 +150,8 @@ void BoolSharing::PrepareSetupPhaseMTs(ABYSetup* setup) {
 			task->rec_flavor = Rec_OT;
 			task->nsndvals = 4;
 			task->numOTs = ceil_divide(m_nNumMTs[0], 2);
-			task->mskfct = fMaskFct;
-			task->delete_mskfct = (i == 0 ? TRUE : FALSE);
+			task->mskfct = new XORMasking(m_vANDs[0].bitlen);
+			task->delete_mskfct = TRUE;
 			if ((m_eRole ^ j) == SERVER) {
 				task->pval.sndval.X = m_vKKS.data();
 			} else {
@@ -169,15 +167,14 @@ void BoolSharing::PrepareSetupPhaseMTs(ABYSetup* setup) {
 #else
 		for (uint32_t i = 0; i < m_nNumANDSizes; i++) {
 #endif
-			fMaskFct = new XORMasking(m_vANDs[i].bitlen);
-
 			for (uint32_t j = 0; j < 2; j++) {
 				IKNP_OTTask* task = (IKNP_OTTask*) malloc(sizeof(IKNP_OTTask));
 				task->bitlen = m_vANDs[i].bitlen;
 				task->snd_flavor = Snd_R_OT;
 				task->rec_flavor = Rec_OT;
 				task->numOTs = m_nNumMTs[i];
-				task->mskfct = fMaskFct;
+				task->mskfct = new XORMasking(m_vANDs[i].bitlen);
+				task->delete_mskfct = TRUE;
 				if ((m_eRole ^ j) == SERVER) {
 					task->pval.sndval.X0 = &(m_vC[i]);
 					task->pval.sndval.X1 = &(m_vB[i]);

--- a/src/abycore/sharing/boolsharing.h
+++ b/src/abycore/sharing/boolsharing.h
@@ -72,7 +72,6 @@ public:
 	void PreComputationPhase();
 
 	inline void InstantiateGate(GATE* gate);
-	inline void UsedGate(uint32_t gateid);
 
 	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
 	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
@@ -188,12 +187,12 @@ private:
 	 */
 	void PrepareSetupPhaseOPLUT(ABYSetup* setup);
 
-	/** 
+	/**
 	 Share Values
 	 \param 	gateid 	GateID
 	 */
 	inline void ShareValues(uint32_t gateid);
-	/** 
+	/**
 	 Reconstruct Values
 	 \param 	gateid 	GateID
 	 */

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -215,34 +215,39 @@ void Sharing::EvaluatePrintValGate(uint32_t gateid, e_circuit circ_type) {
 	free((char*) m_pGates[gateid].gs.infostr);
 }
 
-// What needs to be deleted depends on the gate's context, not the sharing
-// from which the deletion was initiated. This is why this method is here
-// in the Sharing superclass and not its subclasses.
+// Delete dynamically allocated gate contents depending on gate type
+void Sharing::FreeGate(GATE *gate) {
+	e_sharing context = gate->context;
+	e_role role = m_eRole;
+	if(context == S_YAO_REV) {
+		role = (role == SERVER ? CLIENT : SERVER);
+		context = S_YAO;
+	}
+	switch(context) {
+	case S_BOOL:
+	case S_ARITH:
+	case S_SPLUT:
+		free(gate->gs.val);
+		break;
+	case S_YAO:
+		if(role == SERVER) {
+			if(gate->type = G_IN) { break; } // input gates are freed before
+			free(gate->gs.yinput.outKey);
+			free(gate->gs.yinput.pi);
+		} else {
+			free(gate->gs.yval);
+		}
+		break;
+	}
+	gate->instantiated = false;
+}
+
+// Mark gate as used. If it is no longer needed, free it.
 void Sharing::UsedGate(uint32_t gateid) {
 	GATE *gate = &m_pGates[gateid];
 	if(!gate->instantiated) { return; }
 	gate->nused--;
-	if(!gate->nused) {
-		e_sharing context = gate->context;
-		e_role role = m_eRole;
-		if(context == S_YAO_REV) {
-			role = (role == SERVER ? CLIENT : SERVER);
-			context = S_YAO;
-		}
-		switch(context) {
-		case S_BOOL:
-		case S_ARITH:
-		case S_SPLUT:
-			free(gate->gs.val);
-			break;
-		case S_YAO:
-			if(role == SERVER) {
-				free(gate->gs.yinput.outKey);
-				free(gate->gs.yinput.pi);
-			} else {
-				free(gate->gs.yval);
-			}
-		}
-		gate->instantiated = false;
+	if(!gate->nused && gate->type != G_CONV) {
+		FreeGate(gate);
 	}
 }

--- a/src/abycore/sharing/sharing.h
+++ b/src/abycore/sharing/sharing.h
@@ -137,6 +137,12 @@ public:
 	void UsedGate(uint32_t gateid);
 
 	/**
+	 Method for freeing gate memory depending on its type
+	 \param gate		Pointer to the gat to free
+	 */
+	void FreeGate(GATE* gate);
+
+	/**
 	 Method for assigning the input
 	 \param 	input 		Input
 	 */

--- a/src/abycore/sharing/sharing.h
+++ b/src/abycore/sharing/sharing.h
@@ -76,93 +76,93 @@ public:
 	      triggered n times. Also the precomputation phase plays a huge role in these methods.
 	*/
 
-	/**	
+	/**
 	 Method for preparing the sharing setup.
 	 \param 	setup 	Object for setting up the share.
 	 */
 	virtual void PrepareSetupPhase(ABYSetup* setup) = 0;
-	/**	
+	/**
 	 Method for performing the sharing setup.
 	 \param 	setup 	Object for setting up the share.
 	 */
 	virtual void PerformSetupPhase(ABYSetup* setup) = 0;
-	/**	
+	/**
 	 Method for finishing the sharing setup.
 	 \param 	setup 	Object for setting up the share.
 	 */
 	virtual void FinishSetupPhase(ABYSetup* setup) = 0;
 
-	/**	
+	/**
 	 Method for evaluating the local operations.
 	 \param 	level 	_______________________
 	 */
 	virtual void EvaluateLocalOperations(uint32_t level) = 0;
-	/**	
+	/**
 	 Method for evaluating the interactive operations.
 	 \param 	level 	_______________________
 	 */
 	virtual void EvaluateInteractiveOperations(uint32_t level) = 0;
 
-	/**	
+	/**
 	 Method for preparing the online phase <Better description please>
 	 */
 	virtual void PrepareOnlinePhase() = 0;
 
-	/**	
+	/**
 	 Method for finishing the circuit layer <Better description please>
 	 */
 	virtual void FinishCircuitLayer(uint32_t level) = 0;
 
-	/**	
+	/**
 	 Method for sending the data.
 	 \param 	sendbuf 	sender buffer
 	 \param 	bytesize	data size
 	 */
 	virtual void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize) = 0;
-	/**	
+	/**
 	 Method for receiving the data.
 	 \param 	rsvbuf 		receiver buffer
 	 \param 	rcvsize		data size
 	 */
 	virtual void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes) = 0;
-	/**	
+	/**
 	 Method for Instantiating a gate
 	 \param gate 		Input gate
 	 */
 	virtual void InstantiateGate(GATE* gate) = 0;
-	/**	
+	/**
 	 Method for finding the used gate with the gateid.
 	 \param gateid		Id of the used gate.
 	 */
-	virtual void UsedGate(uint32_t gateid) = 0;
+	void UsedGate(uint32_t gateid);
 
-	/**	
+	/**
 	 Method for assigning the input
 	 \param 	input 		Input
 	 */
 	virtual uint32_t AssignInput(CBitVector& input) = 0;
-	/**	
-	 Method for getting the output 
+	/**
+	 Method for getting the output
 	 \param 	output 		Output
 	 */
 	virtual uint32_t GetOutput(CBitVector& out) = 0;
-	/**	
+	/**
 	 Method for finding the maximum communication rounds.
 	 */
 	virtual uint32_t GetMaxCommunicationRounds() = 0;
-	/**	
+	/**
 	 Method for finding the number of non-linear operations.
 	 */
 	virtual uint32_t GetNumNonLinearOperations() = 0;
-	/**	
+	/**
 	 Method for knowing the sharing type used.
 	 */
 	virtual const char* sharing_type() = 0;
-	/**	
+	/**
 	 Method for printing the performance statistics.
 	 */
 	virtual void PrintPerformanceStatistics() = 0;
-	/**	
+	/**
 	 Method for _________________________________
 	 */
 	virtual Circuit* GetCircuitBuildRoutine() = 0;

--- a/src/abycore/sharing/splut.cpp
+++ b/src/abycore/sharing/splut.cpp
@@ -301,6 +301,7 @@ void SetupLUT::PrepareSetupPhase(ABYSetup* setup) {
 					task->nsndvals = 1<<i;
 					task->numOTs = m_vNOTs[j&0x01][i][k].numgates;
 					task->mskfct = fMaskFct;
+					task->delete_mskfct = true;
 					if ((reverse ^ j)) {
 						//cout << "I assigned sender" << endl;
 						task->pval.sndval.X = m_vPreCompOTX[i][k];

--- a/src/abycore/sharing/splut.cpp
+++ b/src/abycore/sharing/splut.cpp
@@ -1420,15 +1420,6 @@ inline void SetupLUT::InstantiateGate(GATE* gate) {
 	gate->instantiated = true;
 }
 
-inline void SetupLUT::UsedGate(uint32_t gateid) {
-	//Decrease the number of further uses of the gate
-	m_pGates[gateid].nused--;
-	//If the gate is needed in another subsequent gate, delete it
-	if (!m_pGates[gateid].nused) {
-		free(m_pGates[gateid].gs.val);
-	}
-}
-
 void SetupLUT::EvaluateSIMDGate(uint32_t gateid) {
 	GATE* gate = m_pGates + gateid;
 	uint32_t vsize = gate->nvals;

--- a/src/abycore/sharing/splut.cpp
+++ b/src/abycore/sharing/splut.cpp
@@ -1684,31 +1684,32 @@ void SetupLUT::Reset() {
 	for (uint32_t i = 0; i < m_vPreCompOTX.size(); i++) {
 		for(uint32_t k = 0; k < m_vPreCompOTX[i].size(); k++) {
 			for(uint32_t j = 0; j < (1<<i); j++) {
-				m_vPreCompOTX[i][k][j]->delCBitVector();
+				delete m_vPreCompOTX[i][k][j];
 			}
+			free(m_vPreCompOTX[i][k]);
 			//m_vPreCompOTX[i][k].resize(0);
 			//free(m_vPreCompOTX[i]);
-			m_vPreCompOTMasks[i][k]->delCBitVector();
+			delete m_vPreCompOTMasks[i][k];
 
-			m_vPreCompOTC[i][k]->delCBitVector();
-			m_vPreCompOTR[i][k]->delCBitVector();
+			delete m_vPreCompOTC[i][k];
+			delete m_vPreCompOTR[i][k];
 
 			//TODO: setting to 0 is probably not required. test this and remove if so
 			m_vPreCompMaskIdx[i][k] = 0;
 			m_vPreCompChoiceIdx[i][k] = 0;
 
 			m_nMaskUpdateSndCtr[i][k] = 0;
-			m_vMaskUpdateSndBuf[i][k]->delCBitVector();
+			delete m_vMaskUpdateSndBuf[i][k];
 			m_nMaskUpdateRcvCtr[i][k] = 0;
-			m_vMaskUpdateRcvBuf[i][k]->delCBitVector();
+			delete m_vMaskUpdateRcvBuf[i][k];
 
 			m_nChoiceUpdateSndCtr[i][k] = 0;
-			m_vChoiceUpdateSndBuf[i][k]->delCBitVector();
+			delete m_vChoiceUpdateSndBuf[i][k];
 			m_nChoiceUpdateRcvCtr[i][k] = 0;
-			m_vChoiceUpdateRcvBuf[i][k]->delCBitVector();
+			delete m_vChoiceUpdateRcvBuf[i][k];
 
 			m_nTableRndIdx[i][k] = 0;
-			m_vTableRnd[i][k]->delCBitVector();
+			delete m_vTableRnd[i][k];
 		}
 		m_vPreCompOTX[i].resize(0);
 		m_vPreCompOTMasks[i].resize(0);

--- a/src/abycore/sharing/splut.h
+++ b/src/abycore/sharing/splut.h
@@ -84,7 +84,6 @@ public:
 	}
 
 	inline void InstantiateGate(GATE* gate);
-	inline void UsedGate(uint32_t gateid);
 
 	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
 	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
@@ -207,12 +206,12 @@ private:
 	 \param 	depth 	gate layer which should be evaluated
 	 */
 	//void Internal_EvaluateInteractiveOperations(uint32_t depth);
-	/** 
+	/**
 	 Share Values
 	 \param 	gateid 	GateID
 	 */
 	inline void ShareValues(uint32_t gateid);
-	/** 
+	/**
 	 Reconstruct Values
 	 \param 	gateid 	GateID
 	 */

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -599,16 +599,6 @@ void YaoClientSharing::InstantiateGate(GATE* gate) {
 	gate->gs.yval = (BYTE*) calloc(m_nSecParamIters * gate->nvals, sizeof(UGATE_T));
 }
 
-void YaoClientSharing::UsedGate(uint32_t gateid) {
-	//Decrease the number of further uses of the gate
-	m_pGates[gateid].nused--;
-	//If the gate is needed in another subsequent gate, delete it
-	if (!m_pGates[gateid].nused && m_pGates[gateid].type != G_CONV) {
-		free(m_pGates[gateid].gs.yval);
-		m_pGates[gateid].instantiated = false;
-	}
-}
-
 void YaoClientSharing::EvaluateSIMDGate(uint32_t gateid) {
 	GATE* gate = m_pGates + gateid;
 	if (gate->type == G_COMBINE) {

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -42,6 +42,10 @@ void YaoClientSharing::InitClient() {
 
 }
 
+YaoClientSharing::~YaoClientSharing() {
+		Reset();
+}
+
 //Pre-set values for new layer
 void YaoClientSharing::InitNewLayer() {
 	m_nServerInBitCtr = 0;

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -47,7 +47,7 @@ YaoClientSharing::~YaoClientSharing() {
 			free(m_vTmpEncBuf[i]);
 		}
 		free(m_vTmpEncBuf);
-		// don't delete fMaskFct: this is done in the ABYSetup::ThreadRun* functions
+		delete fMaskFct;
 }
 
 //Pre-set values for new layer
@@ -100,6 +100,7 @@ void YaoClientSharing::PrepareSetupPhase(ABYSetup* setup) {
 	task->rec_flavor = Rec_OT;
 	task->numOTs = m_nClientInputBits + m_nConversionInputBits;
 	task->mskfct = fMaskFct;
+	task->delete_mskfct = FALSE; // is deleted in destructor
 	task->pval.rcvval.C = &(m_vChoiceBits);
 	task->pval.rcvval.R = &(m_vROTMasks);
 

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -35,7 +35,6 @@ void YaoClientSharing::InitClient() {
 
 	fMaskFct = new XORMasking(m_cCrypto->get_seclvl().symbits);
 
-	//TODO free memory after use
 	m_vTmpEncBuf = (uint8_t**) malloc(sizeof(uint8_t*) * KEYS_PER_GATE_IN_TABLE);
 	for(uint32_t i = 0; i < KEYS_PER_GATE_IN_TABLE; i++)
 		m_vTmpEncBuf[i] = (uint8_t*) malloc(sizeof(uint8_t) * AES_BYTES);
@@ -44,6 +43,11 @@ void YaoClientSharing::InitClient() {
 
 YaoClientSharing::~YaoClientSharing() {
 		Reset();
+		for(size_t i = 0; i < KEYS_PER_GATE_IN_TABLE; i++) {
+			free(m_vTmpEncBuf[i]);
+		}
+		free(m_vTmpEncBuf);
+		delete fMaskFct;
 }
 
 //Pre-set values for new layer
@@ -72,7 +76,6 @@ void YaoClientSharing::PrepareSetupPhase(ABYSetup* setup) {
 	m_nClientInputBits = m_cBoolCircuit->GetNumInputBitsForParty(CLIENT);
 	m_nConversionInputBits = m_cBoolCircuit->GetNumB2YGates() + m_cBoolCircuit->GetNumA2YGates() + m_cBoolCircuit->GetNumYSwitchGates();
 
-	m_vGarbledCircuit.Create(0); //m_nANDGates * KEYS_PER_GATE_IN_TABLE * m_sSecLvl.symbits);
 	buf = (BYTE*) malloc(gt_size);
 	m_vGarbledCircuit.AttachBuf(buf, gt_size);
 

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -47,7 +47,7 @@ YaoClientSharing::~YaoClientSharing() {
 			free(m_vTmpEncBuf[i]);
 		}
 		free(m_vTmpEncBuf);
-		delete fMaskFct;
+		// don't delete fMaskFct: this is done in the ABYSetup::ThreadRun* functions
 }
 
 //Pre-set values for new layer

--- a/src/abycore/sharing/yaoclientsharing.h
+++ b/src/abycore/sharing/yaoclientsharing.h
@@ -37,11 +37,7 @@ public:
 	}
 	;
 	/** Destructor of the class.*/
-	~YaoClientSharing() {
-		Reset();
-		delete m_cBoolCircuit;
-	}
-	;
+	~YaoClientSharing();
 
 	//MEMBER FUNCTIONS FROM SUPER CLASS YAO SHARING
 	void Reset();

--- a/src/abycore/sharing/yaoclientsharing.h
+++ b/src/abycore/sharing/yaoclientsharing.h
@@ -53,7 +53,6 @@ public:
 	void PrepareOnlinePhase();
 
 	void InstantiateGate(GATE* gate);
-	void UsedGate(uint32_t gateid);
 
 	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
 	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -530,7 +530,8 @@ void YaoServerSharing::EvaluateConversionGate(uint32_t gateid) {
 	PrintKey(gate->gs.yinput.outKey);
 	cout << endl;
 #endif
-	UsedGate(gate->ingates.inputs.parents[0]);
+	// not calling UsedGate(gate->ingates.inputs.parents[0]) here:
+	// is called in YaoServerSharing::FinishCircuitLayer()
 }
 
 //TODO: optimize for UINT64_T pointers
@@ -854,6 +855,7 @@ void YaoServerSharing::FinishCircuitLayer(uint32_t level) {
 								m_bTempKeyBuf); //One - key
 					}
 				}
+				UsedGate(input);
 			}
 		}
 	}
@@ -930,17 +932,6 @@ void YaoServerSharing::InstantiateGate(GATE* gate) {
 		exit(0);
 	}
 	gate->instantiated = true;
-}
-
-void YaoServerSharing::UsedGate(uint32_t gateid) {
-	//Decrease the number of further uses of the gate
-	m_pGates[gateid].nused--;
-	//If the gate is needed in another subsequent gate, delete it
-	if (!m_pGates[gateid].nused) {
-		free(m_pGates[gateid].gs.yinput.outKey);
-		free(m_pGates[gateid].gs.yinput.pi);
-		m_pGates[gateid].instantiated = false;
-	}
 }
 
 void YaoServerSharing::EvaluateSIMDGate(uint32_t gateid) {
@@ -1086,6 +1077,7 @@ void YaoServerSharing::Reset() {
 	m_vServerOutputGates.clear();
 
 	free(m_vOutputDestionations);
+	m_vOutputDestionations = nullptr;
 	m_nOutputDestionationsCtr = 0;
 
 	m_nANDGates = 0;

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -47,6 +47,10 @@ void YaoServerSharing::InitServer() {
 	InitNewLayer();
 }
 
+YaoServerSharing::~YaoServerSharing() {
+		Reset();
+}
+
 //Pre-set values for new layer
 void YaoServerSharing::InitNewLayer() {
 	m_nServerKeyCtr = 0;

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -49,6 +49,14 @@ void YaoServerSharing::InitServer() {
 
 YaoServerSharing::~YaoServerSharing() {
 		Reset();
+		for(size_t i = 0; i < 2; i++) {
+			free(m_bLMaskBuf[i]);
+			free(m_bRMaskBuf[i]);
+			free(m_bOKeyBuf[i]);
+		}
+		free(m_bLKeyBuf);
+		free(m_bTmpBuf);
+		delete fMaskFct;
 }
 
 //Pre-set values for new layer

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -85,7 +85,6 @@ void YaoServerSharing::PrepareSetupPhase(ABYSetup* setup) {
 
 	//m_vPreSetInputGates = (input_gate_val_t*) calloc(m_nServerInputBits, sizeof(input_gate_val_t));
 
-	m_vGarbledCircuit.Create(0);
 	buf = (BYTE*) malloc(gt_size);
 	m_vGarbledCircuit.AttachBuf(buf, gt_size);
 
@@ -303,6 +302,7 @@ void YaoServerSharing::SendServerInputKey(uint32_t gateid) {
 			memcpy(m_vServerKeySndBuf.GetArr() + m_nServerKeyCtr * m_nSecParamBytes, m_vServerInputKeys.GetArr() + m_nPermBitCtr * m_nSecParamBytes, m_nSecParamBytes);
 		}
 	}
+	free(input);
 }
 
 void YaoServerSharing::SendClientInputKey(uint32_t gateid) {
@@ -530,6 +530,7 @@ void YaoServerSharing::EvaluateConversionGate(uint32_t gateid) {
 	PrintKey(gate->gs.yinput.outKey);
 	cout << endl;
 #endif
+	UsedGate(gate->ingates.inputs.parents[0]);
 }
 
 //TODO: optimize for UINT64_T pointers
@@ -729,6 +730,7 @@ void YaoServerSharing::EvaluateOutputGate(GATE* gate) {
 #ifdef DEBUGYAOSERVER
 	cout << "Stored output share " << gate->gs.val[0] << endl;
 #endif
+	UsedGate(parentid);
 }
 
 void YaoServerSharing::GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& sndbytes) {
@@ -1083,8 +1085,7 @@ void YaoServerSharing::Reset() {
 	m_vOutputShareGates.clear();
 	m_vServerOutputGates.clear();
 
-	if (m_nOutputDestionationsCtr > 0)
-		free(m_vOutputDestionations);
+	free(m_vOutputDestionations);
 	m_nOutputDestionationsCtr = 0;
 
 	m_nANDGates = 0;

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -29,7 +29,7 @@ void YaoServerSharing::InitServer() {
 	m_bLKeyBuf = (BYTE*) malloc(sizeof(BYTE) * m_nSecParamBytes);
 	m_bTmpBuf = (BYTE*) malloc(sizeof(BYTE) * AES_BYTES);
 
-
+	m_vOutputDestionations = nullptr;
 
 	m_nGarbledTableCtr = 0L;
 	m_nGarbledTableSndCtr = 0L;

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -135,6 +135,7 @@ void YaoServerSharing::PrepareSetupPhase(ABYSetup* setup) {
 	task->rec_flavor = Rec_OT;
 	task->numOTs = m_nClientInputBits + m_nConversionInputBits;
 	task->mskfct = fMaskFct;
+	task->delete_mskfct = FALSE; // is deleted in destructor
 	task->pval.sndval.X0 = &(m_vROTMasks[0]);
 	task->pval.sndval.X1 = &(m_vROTMasks[1]);
 

--- a/src/abycore/sharing/yaoserversharing.h
+++ b/src/abycore/sharing/yaoserversharing.h
@@ -42,11 +42,7 @@ public:
 	/**
 	 Destructor of the class.
 	 */
-	~YaoServerSharing() {
-		Reset();
-		delete m_cBoolCircuit;
-	}
-	;
+	~YaoServerSharing();
 
 	//MEMBER FUNCTIONS FROM SUPER CLASS YAO SHARING
 	void Reset();

--- a/src/abycore/sharing/yaoserversharing.h
+++ b/src/abycore/sharing/yaoserversharing.h
@@ -58,7 +58,6 @@ public:
 	void PrepareOnlinePhase();
 
 	void InstantiateGate(GATE* gate);
-	void UsedGate(uint32_t gateid);
 
 	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
 	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);

--- a/src/abycore/sharing/yaosharing.cpp
+++ b/src/abycore/sharing/yaosharing.cpp
@@ -21,7 +21,7 @@
 void YaoSharing::Init() {
 	/* init the class for correctly sized Yao key operations*/
 	InitYaoKey(&m_pKeyOps, m_cCrypto->get_seclvl().symbits);
-	
+
 	m_cBoolCircuit = new BooleanCircuit(m_pCircuit, m_eRole, m_eContext);
 
 	m_bZeroBuf = (BYTE*) calloc(m_nSecParamBytes, sizeof(BYTE));
@@ -36,6 +36,18 @@ void YaoSharing::Init() {
 #endif
 
 	m_nSecParamIters = ceil_divide(m_nSecParamBytes, sizeof(UGATE_T));
+}
+
+YaoSharing::~YaoSharing() {
+	delete m_pKeyOps;
+	delete m_cBoolCircuit;
+	free(m_bZeroBuf);
+	free(m_bTempKeyBuf);
+#ifdef FIXED_KEY_GARBLING
+	free(m_bResKeyBuf);
+	m_cCrypto->clean_aes_key(m_kGarble);
+	free(m_kGarble);
+#endif
 }
 
 BOOL YaoSharing::EncryptWire(BYTE* c, BYTE* p, uint32_t id)

--- a/src/abycore/sharing/yaosharing.h
+++ b/src/abycore/sharing/yaosharing.h
@@ -37,8 +37,8 @@ typedef struct {
 } a2y_gate_pos_t;
 
 
-/** 
- \def 	KEYS_PER_GATE_IN_TABLE 
+/**
+ \def 	KEYS_PER_GATE_IN_TABLE
  \brief	____________________
  */
 #define KEYS_PER_GATE_IN_TABLE 2
@@ -57,10 +57,7 @@ public:
 	}
 	;
 	/** Destructor for the class. */
-	~YaoSharing() {
-		//TODO deallocate things here
-	}
-	;
+	virtual ~YaoSharing();
 
 	// METHODS FROM SUPER CLASS SHARING...
 	virtual void Reset() = 0;
@@ -103,7 +100,7 @@ public:
 	void PrintPerformanceStatistics();
 	//SUPER CLASS METHODS END HERE...
 
-	/** 
+	/**
 	 Evaluating SIMD Gate.
 	 \param 	gateid 	Identifier of the gate to be evaluated.
 	 */
@@ -156,11 +153,11 @@ protected:
 	/** Initiator function. This method is invoked from the constructor of the class.*/
 	void Init();
 
-	/**	
-	 Encrypt Wire Function <DETAILED DESCRIPTION> 
+	/**
+	 Encrypt Wire Function <DETAILED DESCRIPTION>
 	 \param  c 		________________
 	 \param  p 		________________
-	 \param  id 		________________	
+	 \param  id 		________________
 	 */
 	BOOL EncryptWire(BYTE* c, BYTE* p, uint32_t id);
 

--- a/src/abycore/sharing/yaosharing.h
+++ b/src/abycore/sharing/yaosharing.h
@@ -75,7 +75,6 @@ public:
 	}
 
 	virtual void InstantiateGate(GATE* gate) = 0;
-	virtual void UsedGate(uint32_t gateid) = 0;
 
 	virtual void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize) = 0;
 	virtual void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes) = 0;

--- a/src/abycore/util/channel.h
+++ b/src/abycore/util/channel.h
@@ -30,7 +30,6 @@ public:
 		if(m_bRcvAlive) {
 			m_cRcver->remove_listener(m_bChannelID);
 		}
-
 		delete m_eRcved;
 		delete m_eFin;
 	}
@@ -60,8 +59,10 @@ public:
 		assert(m_bRcvAlive);
 		while(m_qRcvedBlocks->empty())
 			m_eRcved->Wait();
-		uint8_t* ret_block = ((rcv_ctx*)m_qRcvedBlocks->front())->buf;
+		rcv_ctx* ret = (rcv_ctx*) m_qRcvedBlocks->front();
+		uint8_t* ret_block = ret->buf;
 		m_qRcvedBlocks->pop();
+		free(ret);
 
 		return ret_block;
 	}
@@ -71,8 +72,8 @@ public:
 		while(m_qRcvedBlocks->empty())
 			m_eRcved->Wait();
 
-
-		uint8_t* ret_block = ((rcv_ctx*) m_qRcvedBlocks->front())->buf;
+		rcv_ctx* ret = (rcv_ctx*) m_qRcvedBlocks->front();
+		uint8_t* ret_block = ret->buf;
 		uint64_t rcved_this_call = ((rcv_ctx*) m_qRcvedBlocks->front())->rcvbytes;
 		if(rcved_this_call == rcvsize) {
 			m_qRcvedBlocks->pop();
@@ -93,6 +94,7 @@ public:
 		}
 		memcpy(rcvbuf, ret_block, rcved_this_call);
 		free(ret_block);
+		free(ret);
 	}
 
 

--- a/src/abycore/util/channel.h
+++ b/src/abycore/util/channel.h
@@ -74,19 +74,21 @@ public:
 
 		rcv_ctx* ret = (rcv_ctx*) m_qRcvedBlocks->front();
 		uint8_t* ret_block = ret->buf;
-		uint64_t rcved_this_call = ((rcv_ctx*) m_qRcvedBlocks->front())->rcvbytes;
+		uint64_t rcved_this_call = ret->rcvbytes;
 		if(rcved_this_call == rcvsize) {
 			m_qRcvedBlocks->pop();
+			free(ret);
 		} else if(rcvsize < rcved_this_call) {
 			//if the block contains too much data, copy only the receive size
-			((rcv_ctx*) m_qRcvedBlocks->front())->rcvbytes -= rcvsize;
-			uint8_t* newbuf = (uint8_t*) malloc(((rcv_ctx*) m_qRcvedBlocks->front())->rcvbytes);
-			memcpy(newbuf, ((rcv_ctx*) m_qRcvedBlocks->front())->buf+rcvsize, ((rcv_ctx*) m_qRcvedBlocks->front())->rcvbytes);
-			((rcv_ctx*) m_qRcvedBlocks->front())->buf = newbuf;
+			ret->rcvbytes -= rcvsize;
+			uint8_t* newbuf = (uint8_t*) malloc(ret->rcvbytes);
+			memcpy(newbuf, ret->buf+rcvsize, ret->rcvbytes);
+			ret->buf = newbuf;
 			rcved_this_call = rcvsize;
 		} else {
 			//I want to receive more data than are in that block. Perform recursive call (might become troublesome for too many recursion steps)
 			m_qRcvedBlocks->pop();
+			free(ret);
 			uint8_t* new_rcvbuf_start = rcvbuf + rcved_this_call;
 			uint64_t new_rcvsize = rcvsize -rcved_this_call;
 
@@ -94,7 +96,6 @@ public:
 		}
 		memcpy(rcvbuf, ret_block, rcved_this_call);
 		free(ret_block);
-		free(ret);
 	}
 
 

--- a/src/abycore/util/rcvthread.h
+++ b/src/abycore/util/rcvthread.h
@@ -42,7 +42,7 @@ public:
 	}
 	;
 	~RcvThread() {
-		this->Kill();
+		this->Wait();
 		delete rcvlock;
 		free(listeners);
 	}

--- a/src/abycore/util/rcvthread.h
+++ b/src/abycore/util/rcvthread.h
@@ -43,11 +43,12 @@ public:
 	;
 	~RcvThread() {
 		this->Wait();
-		delete rcvlock;
 		for(uint32_t i = 0; i < MAX_NUM_COMM_CHANNELS; i++) {
+			flush_queue(i);
 			delete listeners[i].rcv_buf;
 		}
 		free(listeners);
+		delete rcvlock;
 	}
 	;
 

--- a/src/abycore/util/rcvthread.h
+++ b/src/abycore/util/rcvthread.h
@@ -133,7 +133,6 @@ public:
 #ifdef DEBUG_RECEIVE_THREAD
 					cout << "Receiver thread is being killed" << endl;
 #endif
-					m_bRunning = false;
 					return;//continue;
 				}
 

--- a/src/abycore/util/rcvthread.h
+++ b/src/abycore/util/rcvthread.h
@@ -44,6 +44,9 @@ public:
 	~RcvThread() {
 		this->Wait();
 		delete rcvlock;
+		for(uint32_t i = 0; i < MAX_NUM_COMM_CHANNELS; i++) {
+			delete listeners[i].rcv_buf;
+		}
 		free(listeners);
 	}
 	;

--- a/src/abycore/util/sndthread.h
+++ b/src/abycore/util/sndthread.h
@@ -84,7 +84,7 @@ public:
 		snd_task* task = (snd_task*) malloc(sizeof(snd_task));
 		task->channelid = ADMIN_CHANNEL;
 		task->bytelen = 1;
-		task->snd_buf = (uint8_t*) malloc(1);
+		task->snd_buf = (uint8_t*) calloc(1, 1);
 
 		sndlock->Lock();
 		send_tasks.push(task);

--- a/src/abycore/util/thread.h
+++ b/src/abycore/util/thread.h
@@ -128,6 +128,7 @@ public:
 	BOOL Wait() {
 		if (!m_bRunning)
 			return TRUE;
+		m_bRunning = FALSE;
 		return pthread_join(m_pThread, NULL) == 0;
 	}
 
@@ -147,7 +148,6 @@ protected:
 	static void* ThreadMainHandler(void* p) {
 		CThread* pThis = (CThread*) p;
 		pThis->ThreadMain();
-		pThis->m_bRunning = FALSE;
 		return 0;
 	}
 

--- a/src/abycore/util/thread.h
+++ b/src/abycore/util/thread.h
@@ -4,12 +4,12 @@
  \copyright	________________
  */
 
-#ifndef __THREAD_H__BY_SGCHOI  
-#define __THREAD_H__BY_SGCHOI 
+#ifndef __THREAD_H__BY_SGCHOI
+#define __THREAD_H__BY_SGCHOI
 
 #include "typedefs.h"
 
-#ifdef WIN32 
+#ifdef WIN32
 
 #include <process.h>
 
@@ -108,7 +108,7 @@ protected:
 	HANDLE m_hHandle;
 };
 
-#else // NOT WIN32 
+#else // NOT WIN32
 #include <pthread.h>
 class CThread {
 public:
@@ -253,4 +253,3 @@ public:
 };
 
 #endif //__THREAD_H__BY_SGCHOI
-

--- a/src/abycore/util/thread.h
+++ b/src/abycore/util/thread.h
@@ -76,6 +76,7 @@ public:
 	BOOL Wait()
 	{
 		if( !m_bRunning ) return TRUE;
+		m_bRunning = FALSE;
 		return WaitForSingleObject(m_hHandle, INFINITE) == WAIT_OBJECT_0;
 	}
 
@@ -99,7 +100,6 @@ protected:
 	{
 		CThread* pThis = (CThread*) p;
 		pThis->ThreadMain();
-		pThis->m_bRunning = FALSE;
 		return 0;
 	}
 

--- a/src/examples/aes/common/aescircuit.cpp
+++ b/src/examples/aes/common/aescircuit.cpp
@@ -301,7 +301,7 @@ vector<uint32_t> AESSBox_Forward_BP_Size_Optimized(vector<uint32_t> input, Boole
 	vector<uint32_t> y(22);
 	vector<uint32_t> t(68);
 	vector<uint32_t> s(8);
-	vector<uint32_t> z(17);
+	vector<uint32_t> z(18);
 	vector<uint32_t> out(8);
 
 	for(uint32_t i = 0; i < x.size(); i++) {
@@ -698,4 +698,3 @@ void verify_AES_encryption(uint8_t* input, uint8_t* key, uint32_t nvals, uint8_t
 	}
 	free(aes_key);
 }
-


### PR DESCRIPTION
This is an attempt to get ABY free of memory leaks. Currently, this includes only the main library, but not the example binaries. For the latter there needs to be a way to handle the share pointers that are returned by most circuit-building functions. One possible approach would be to wrap them in a new class that contains a C++11 smart pointer (i.e., a `std::shared_ptr<share>`). This would preserve compatibility with existing code and requires only minor changes to the examples. However, there might be other approaches that work better, so feel free to comment if you have an idea.

Right now, this PR depends on my fork of the OTExtension library. I'll change it back to the original repository as soon as the [corresponding PR](https://github.com/encryptogroup/OTExtension/pull/9) there is merged.