### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/abycore/ABY_utils/convtypes.h
+++ b/src/abycore/ABY_utils/convtypes.h
@@ -6,24 +6,24 @@ typedef enum conv_t{
 
 class ConvType{
 public:
-    virtual conv_t getType(){}
+    virtual conv_t getType() = 0;
 };
 
 class FPType: public ConvType{
 public:
 	FPType(){};
- 	conv_t getType(){return ENUM_FP_TYPE;}
- 	virtual uint32_t getBase(){}
- 	virtual uint32_t getNumOfDigits(){}
- 	virtual uint32_t getExpBits(){}
-   	virtual uint32_t getExpBias(){}
+	conv_t getType(){return ENUM_FP_TYPE;}
+	virtual uint32_t getBase() = 0;
+	virtual uint32_t getNumOfDigits() = 0;
+	virtual uint32_t getExpBits() = 0;
+	virtual uint32_t getExpBias() = 0;
 };
 
 class UINTType: public ConvType{
 public:
 	UINTType(){};
  	conv_t getType(){return ENUM_UINT_TYPE;}
- 	virtual uint32_t getNumOfDigits(){};
+	virtual uint32_t getNumOfDigits() = 0;
 };
 
 class FP32: public FPType{

--- a/src/abycore/circuit/circuit.h
+++ b/src/abycore/circuit/circuit.h
@@ -370,32 +370,32 @@ public:
 		cout << "IN gate not implemented in super-class, stopping!" << endl;
 		return -1;
 	}
-	;
+
 	template<class T> uint32_t PutINGate(T val, e_role role) {
 		cout << "IN gate not implemented in super-class, stopping!" << endl;
 		return -1;
 	}
-	;
+
 	template<class T> uint32_t PutSharedINGate(T val) {
 		cout << "IN gate not implemented in super-class, stopping!" << endl;
 		return -1;
 	}
-	;
+
 	template<class T> uint32_t PutSIMDINGate(uint32_t nvals, T val) {
 		cout << "IN gate not implemented in super-class, stopping!" << endl;
 		return -1;
 	}
-	;
+
 	template<class T> uint32_t PutSIMDINGate(uint32_t nvals, T val, e_role role) {
 		cout << "IN gate not implemented in super-class, stopping!" << endl;
 		return -1;
 	}
-	;
+
 	template<class T> uint32_t PutSharedSIMDINGate(uint32_t nvals, T val) {
 		cout << "IN gate not implemented in super-class, stopping!" << endl;
 		return -1;
 	}
-	;
+
 	virtual share* PutOUTGate(share* parent, e_role dst) =0;
 
 	virtual share* PutSharedOUTGate(share* parent) =0;


### PR DESCRIPTION
This fixes some compiler warnings from clang.

I made the base classes in `src/abycore/ABY_utils/convtypes.h` abstract by using pure virtual methods.