### PR TITLE
fix equality comparison instead of assignment

### DIFF
--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -201,7 +201,8 @@ void Sharing::FreeGate(GATE *gate) {
 		break;
 	case S_YAO:
 		if(role == SERVER) {
-			if(gate->type = G_IN) { break; } // input gates are freed before
+			// input gates are freed before
+			if(gate->type == G_IN || gate->type == G_CONV) { break; }
 			free(gate->gs.yinput.outKey);
 			free(gate->gs.yinput.pi);
 		} else {


### PR DESCRIPTION
Hello,
I think this should be a comparison and not an assignment.

```
/home/lennart/git/ABY-build/extern/ABY/src/abycore/sharing/sharing.cpp:204:18: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                        if(gate->type = G_IN) { break; } // input gates are freed before
                           ~~~~~~~~~~~^~~~~~
/home/lennart/git/ABY-build/extern/ABY/src/abycore/sharing/sharing.cpp:204:18: note: place parentheses around the assignment to silence this warning
                        if(gate->type = G_IN) { break; } // input gates are freed before
                                      ^
                           (                )
/home/lennart/git/ABY-build/extern/ABY/src/abycore/sharing/sharing.cpp:204:18: note: use '==' to turn this assignment into an equality comparison
                        if(gate->type = G_IN) { break; } // input gates are freed before
                                      ^
                                      ==
```