### PR TITLE
Remove unnecessary allocations, cleanup

### DIFF
--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -618,25 +618,21 @@ share* BooleanCircuit::PutSharedOUTGate(share* parent) {
 
 share* BooleanCircuit::PutCONSGate(UGATE_T val, uint32_t bitlen) {
 	share* shr = new boolshare(bitlen, this);
-	UGATE_T tmpval;
 	for (uint32_t i = 0; i < bitlen; i++) {
-		(val>>i) & 0x01 ? tmpval = ~0: tmpval = 0;
-		tmpval = tmpval % (1<<1);
-		shr->set_wire_id(i, PutConstantGate(tmpval, 1));
+		if ((val >> i) & 0x01) {
+			shr->set_wire_id(i, PutConstantGate(1, 1));
+		} else {
+			shr->set_wire_id(i, PutConstantGate(0, 1));
+		}
 	}
 	return shr;
 }
 
 share* BooleanCircuit::PutCONSGate(uint8_t* val, uint32_t bitlen) {
 	share* shr = new boolshare(bitlen, this);
-	uint32_t bytelen = ceil_divide(bitlen, 8);
-	uint32_t valbytelen = ceil_divide(1, 8);
-	uint8_t* tmpval = (uint8_t*) malloc(valbytelen);
-
 	for (uint32_t i = 0; i < bitlen; i++) {
 		shr->set_wire_id(i, PutConstantGate(val[i] & 0x01, 1));
 	}
-	free(tmpval);
 	return shr;
 }
 
@@ -650,32 +646,22 @@ share* BooleanCircuit::PutCONSGate(uint32_t* val, uint32_t bitlen) {
 
 share* BooleanCircuit::PutSIMDCONSGate(uint32_t nvals, UGATE_T val, uint32_t bitlen) {
 	share* shr = new boolshare(bitlen, this);
-	uint32_t ugate_iters = ceil_divide(nvals, sizeof(UGATE_T) * 8);
-	UGATE_T *tmparray = (UGATE_T*) calloc(ugate_iters, sizeof(UGATE_T));
-	UGATE_T tmpval;
-	uint32_t j;
 	for (uint32_t i = 0; i < bitlen; i++) {
-		(val>>i) & 0x01 ? tmpval = ~(0L): tmpval = 0L;
-		for(j = 0; j < ugate_iters-1; j++) {
-			tmparray[j] = tmpval;
+		if ((val >> i) & 0x01) {
+			shr->set_wire_id(i, PutConstantGate(~0L, nvals));
 		}
-		tmparray[j] = tmpval & (((1L)<<(nvals%64))-1L);
-		shr->set_wire_id(i, PutConstantGate(tmpval, nvals));
+		else {
+			shr->set_wire_id(i, PutConstantGate(0L, nvals));
+		}
 	}
-	free(tmparray);
 	return shr;
 }
 
 share* BooleanCircuit::PutSIMDCONSGate(uint32_t nvals, uint8_t* val, uint32_t bitlen) {
 	share* shr = new boolshare(bitlen, this);
-	uint32_t bytelen = ceil_divide(bitlen, 8);
-	uint32_t valbytelen = ceil_divide(nvals, 8);
-	uint8_t* tmpval = (uint8_t*) malloc(valbytelen);
-
 	for (uint32_t i = 0; i < bitlen; i++) {
 		shr->set_wire_id(i, PutConstantGate(val[i] & 0x01, nvals));
 	}
-	free(tmpval);
 	return shr;
 }
 


### PR DESCRIPTION
Hi,

I have started to clean up some code. For now I have removed some unnecessary variables and allocations in `Booleancircuit`, and also clarified some operations.

For example in [`BooleanCircuit::PutSIMDCONSGate`](https://github.com/encryptogroup/ABY/blob/c1ff987cc0c51d10d473a17f75a9ae4bc2f60700/src/abycore/circuit/booleancircuits.cpp#L651-L667), the buffer `tmparray` is filled with some values but never used, and in [`BooleanCircuit::PutCONSGate`](https://github.com/encryptogroup/ABY/blob/c1ff987cc0c51d10d473a17f75a9ae4bc2f60700/src/abycore/circuit/booleancircuits.cpp#L623-L625) I have replaced this complicated looking piece of code with a simple if/else that achieves the same (someone should check this).

Since there is probably more to come, this can also be merged later (if approved).