### PR TITLE
Use mutex in communication debugging output

### DIFF
--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -25,9 +25,7 @@ using namespace std;
 
 #ifdef _DEBUG
 #include <cassert>
-using namespace std;
 #endif
-
 
 ABYParty::ABYParty(e_role pid, char* addr, uint16_t port, seclvl seclvl, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mg_algo, uint32_t maxgates) {
 	StartWatch("Initialization", P_INIT);
@@ -425,7 +423,9 @@ BOOL ABYParty::ThreadSendValues() {
 			snd_buf_size_total += sndbytes[j][i];
 			//m_tPartyChan->send(sendbuf[j][i], sndbytes[j][i]);
 #ifdef DEBUGCOMM
-				cout << "(" << m_nDepth << ") Sending " << sndbytes[j][i] << " bytes on socket " << m_eRole << " for sharing " << j << endl;
+			cout_mutex.lock();
+			cout << "(" << m_nDepth << ") Sending " << sndbytes[j][i] << " bytes on socket " << m_eRole << " for sharing " << j << endl;
+			cout_mutex.unlock();
 #endif
 		}
 		//sendbuf[j].clear();
@@ -445,7 +445,6 @@ BOOL ABYParty::ThreadSendValues() {
 		//m_vSockets[2]->Send(snd_buf_total, snd_buf_size_total);
 		m_tPartyChan->send(snd_buf_total, snd_buf_size_total);
 	}
-
 	free(snd_buf_total);
 
 	return true;
@@ -464,7 +463,9 @@ BOOL ABYParty::ThreadReceiveValues() {
 			rcvbytestotal += rcvbytes[j][i];
 			//	m_tPartyChan->blocking_receive(sendbuf[j][i], sndbytes[j][i]);
 #ifdef DEBUGCOMM
+			cout_mutex.lock();
 			cout << "(" << m_nDepth << ") Receiving " << rcvbytes[j][i] << " bytes on socket " << (m_eRole^1) << " for sharing " << j << endl;
+			cout_mutex.unlock();
 #endif
 		}
 	}

--- a/src/abycore/aby/abyparty.h
+++ b/src/abycore/aby/abyparty.h
@@ -44,6 +44,9 @@
 #include <limits.h>
 #include "../ENCRYPTO_utils/connection.h"
 
+#ifdef DEBUGCOMM
+#include <mutex>
+#endif
 
 using namespace std; //TODO eventually remove and prefix couts etc with std::
 
@@ -132,6 +135,9 @@ private:
 	comm_ctx* m_tComm;
 
 	channel* m_tPartyChan;
+#if DEBUGCOMM
+	std::mutex cout_mutex;
+#endif
 
 	class CPartyWorkerThread: public CThread {
 	public:

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -125,7 +125,7 @@ uint32_t ABYCircuit::PutPrimitiveGate(e_gatetype type, uint32_t inleft, uint32_t
 
 #ifdef DEBUG_CIRCUIT_CONSTRUCTION
 	cout << "New primitive gate with id: " << m_nNextFreeGate << ", left in = " << inleft << ", right in = " << inright << ", nvals = " << gate->nvals <<
-	", depth = " << gate->depth << ", sharingsize = " << gate->sharebitlen << ", nrounds = " << gate->nrounds << ", and mindepth = " << mindepth << endl;
+	", depth = " << gate->depth << ", sharingsize = " << gate->sharebitlen << ", nrounds = " << gate->nrounds << endl;
 #endif
 
 	return m_nNextFreeGate++;


### PR DESCRIPTION
Otherwise, send and receive threads write to `cout` at the same time, which possibly leads to interleaved output.