### PR TITLE
Removed using namespace std from aby headers

### DIFF
--- a/src/abycore/ABY_utils/ABYconstants.h
+++ b/src/abycore/ABY_utils/ABYconstants.h
@@ -63,9 +63,6 @@
 
 #define USE_MULTI_MUX_GATES
 
-//TODO eventually remove this and prefix all couts, etc with std::
-using namespace std;
-
 /**
  \enum 	e_role
  \brief	Defines the role of the party or the source / target for certain operations (e.g., input/output)
@@ -206,7 +203,7 @@ typedef struct {
 	std::string opname;
 } aby_ops_t;
 
-static string get_circuit_type_name(e_circuit c) {
+static std::string get_circuit_type_name(e_circuit c) {
 	switch(c) {
 	case C_BOOLEAN:
 		return "BOOLEAN";
@@ -217,7 +214,7 @@ static string get_circuit_type_name(e_circuit c) {
 	}
 }
 
-static string get_role_name(e_role r) {
+static std::string get_role_name(e_role r) {
 	switch(r) {
 	case SERVER:
 		return "SERVER";
@@ -230,7 +227,7 @@ static string get_role_name(e_role r) {
 	}
 }
 
-static string get_sharing_name(e_sharing s) {
+static std::string get_sharing_name(e_sharing s) {
 	switch (s) {
 	case S_BOOL:
 		return "Bool";
@@ -247,7 +244,7 @@ static string get_sharing_name(e_sharing s) {
 	}
 }
 
-static string get_gate_type_name(e_gatetype g) {
+static std::string get_gate_type_name(e_gatetype g) {
 	switch (g) {
 	case G_LIN: return "Linear";
 	case G_NON_LIN: return "Non-Linear";
@@ -281,7 +278,7 @@ typedef enum fp_op_setting{
 }fp_op_setting;
 
 
-static string get_op_name(e_operation op) {
+static std::string get_op_name(e_operation op) {
 	switch (op) {
 	case OP_XOR:
 		return "XOR";

--- a/src/abycore/DGK/dgkparty.cpp
+++ b/src/abycore/DGK/dgkparty.cpp
@@ -18,6 +18,8 @@
 
 #include "dgkparty.h"
 
+using namespace std;
+
 #define CHECKMT 0
 #define DGK_DEBUG 0
 #define NETDEBUG 0

--- a/src/abycore/DGK/dgkparty.h
+++ b/src/abycore/DGK/dgkparty.h
@@ -27,8 +27,6 @@
 #include "../ENCRYPTO_utils/powmod.h"
 #include "../ENCRYPTO_utils/channel.h"
 
-using namespace std;
-
 class DGKParty {
 public:
 	DGKParty(UINT DGKbits, UINT sharelen, UINT readkey);

--- a/src/abycore/DJN/djnparty.cpp
+++ b/src/abycore/DJN/djnparty.cpp
@@ -18,6 +18,8 @@
 
 #include "djnparty.h"
 
+using namespace std;
+
 #define CHECKMT 0
 #define DJN_DEBUG 0
 #define NETDEBUG 0

--- a/src/abycore/DJN/djnparty.h
+++ b/src/abycore/DJN/djnparty.h
@@ -27,8 +27,6 @@
 #include "../ENCRYPTO_utils/powmod.h"
 #include "../ENCRYPTO_utils/channel.h"
 
-using namespace std;
-
 class DJNParty {
 public:
 	DJNParty(UINT DJNbits, UINT sharelen);

--- a/src/abycore/aby/abyparty.h
+++ b/src/abycore/aby/abyparty.h
@@ -48,16 +48,13 @@
 #include <mutex>
 #endif
 
-using namespace std; //TODO eventually remove and prefix couts etc with std::
-
-
 class ABYParty {
 public:
 	ABYParty(e_role pid, char* addr = (char*) "127.0.0.1", uint16_t port = 7766, seclvl seclvl = LT, uint32_t bitlen = 32,
 			uint32_t nthreads =	2, e_mt_gen_alg mg_algo = MT_OT, uint32_t maxgates = 4000000);
 	~ABYParty();
 
-	vector<Sharing*>& GetSharings() {
+        std::vector<Sharing*>& GetSharings() {
 		return m_vSharings;
 	}
 	CBitVector ExecCircuit();
@@ -100,7 +97,7 @@ private:
 	ABYSetup* m_pSetup;
 
 	// Network Communication
-	vector<CSocket*> m_vSockets; // sockets for threads
+	std::vector<CSocket*> m_vSockets; // sockets for threads
 	e_role m_eRole; // thread id
 	uint16_t m_nPort;
 	seclvl m_sSecLvl;
@@ -162,7 +159,7 @@ private:
 	BOOL WaitWorkerThreads();
 	BOOL ThreadNotifyTaskDone(BOOL);
 
-	vector<CPartyWorkerThread*> m_vThreads;
+	std::vector<CPartyWorkerThread*> m_vThreads;
 	CEvent m_evt;
 	CLock m_lock;
 

--- a/src/abycore/aby/abysetup.h
+++ b/src/abycore/aby/abysetup.h
@@ -166,12 +166,12 @@ private:
 	BOOL ThreadRunDGKMTGen(uint32_t threadid);
 
 	// IKNP OTTask values
-	vector<vector<IKNP_OTTask*> > m_vIKNPOTTasks;
+	std::vector<std::vector<IKNP_OTTask*> > m_vIKNPOTTasks;
 
 	// KK OTTask values
-	vector<vector<KK_OTTask*> > m_vKKOTTasks;
+	std::vector<std::vector<KK_OTTask*> > m_vKKOTTasks;
 
-	vector<PKMTGenVals*> m_vPKMTGenTasks;
+	std::vector<PKMTGenVals*> m_vPKMTGenTasks;
 	DJNParty* m_cPaillierMTGen;
 	DGKParty** m_cDGKMTGen;
 

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -18,6 +18,11 @@
 
 #include "abycircuit.h"
 
+#include <string>
+#include <iostream>
+#include <vector>
+
+using namespace std;
 void ABYCircuit::Cleanup() {
 	Reset();
 	free(m_pGates);

--- a/src/abycore/circuit/abycircuit.h
+++ b/src/abycore/circuit/abycircuit.h
@@ -22,9 +22,10 @@
 #include "../ENCRYPTO_utils/typedefs.h"
 #include "../ABY_utils/ABYconstants.h"
 #include <iostream>
+#include <string>
+#include <vector>
 #include <fstream>
 #include <limits.h>
-#include <deque>
 #include "../ENCRYPTO_utils/constants.h"
 #include "../ENCRYPTO_utils/utils.h"
 
@@ -157,7 +158,7 @@ struct GATE {
 	input_gates ingates;		// the number of input gates together with the values of the input gates
 };
 
-string GetOpName(e_gatetype op);
+std::string GetOpName(e_gatetype op);
 
 struct non_lin_vec_ctx {
 	uint32_t bitlen;
@@ -168,7 +169,7 @@ struct tt_lens_ctx {
 	uint32_t tt_len;
 	uint32_t numgates;
 	uint32_t out_bits;
-	vector<uint64_t*> ttable_values;//only needed for OP-LUT, since the tables need to be known during the setup phase
+        std::vector<uint64_t*> ttable_values;//only needed for OP-LUT, since the tables need to be known during the setup phase
 };
 
 uint32_t FindBitLenPositionInVec(uint32_t bitlen, non_lin_vec_ctx* list, uint32_t listentries);
@@ -188,21 +189,21 @@ public:
 
 	uint32_t PutPrimitiveGate(e_gatetype type, uint32_t inleft, uint32_t inright, uint32_t rounds);
 	uint32_t PutNonLinearVectorGate(e_gatetype type, uint32_t choiceinput, uint32_t vectorinput, uint32_t rounds);
-	uint32_t PutCombinerGate(vector<uint32_t> input);
+	uint32_t PutCombinerGate(std::vector<uint32_t> input);
 	uint32_t PutSplitterGate(uint32_t input, uint32_t pos, uint32_t bitlen);
-	vector<uint32_t> PutSplitterGate(uint32_t input, vector<uint32_t> bitlen = vector<uint32_t>());		//, vector<uint32_t> gatelengths = NULL);
-	uint32_t PutCombineAtPosGate(vector<uint32_t> input, uint32_t pos);
+        std::vector<uint32_t> PutSplitterGate(uint32_t input, std::vector<uint32_t> bitlen = std::vector<uint32_t>());		//, vector<uint32_t> gatelengths = NULL);
+	uint32_t PutCombineAtPosGate(std::vector<uint32_t> input, uint32_t pos);
 	uint32_t PutSubsetGate(uint32_t input, uint32_t* posids, uint32_t nvals_out, bool copy_posids);
-	uint32_t PutStructurizedCombinerGate(vector<uint32_t> input, uint32_t pos_start, uint32_t pos_incr, uint32_t nvals);
+	uint32_t PutStructurizedCombinerGate(std::vector<uint32_t> input, uint32_t pos_start, uint32_t pos_incr, uint32_t nvals);
 	uint32_t PutRepeaterGate(uint32_t input, uint32_t nvals);
-	vector<uint32_t> PutRepeaterGate(vector<uint32_t> input, uint32_t nvals);
-	uint32_t PutPermutationGate(vector<uint32_t> input, uint32_t* positions);
+        std::vector<uint32_t> PutRepeaterGate(std::vector<uint32_t> input, uint32_t nvals);
+	uint32_t PutPermutationGate(std::vector<uint32_t> input, uint32_t* positions);
 
 	uint32_t PutOUTGate(uint32_t in, e_role dst, uint32_t rounds);
-	vector<uint32_t> PutOUTGate(vector<uint32_t> in, e_role dst, uint32_t rounds);
+        std::vector<uint32_t> PutOUTGate(std::vector<uint32_t> in, e_role dst, uint32_t rounds);
 
 	uint32_t PutSharedOUTGate(uint32_t in);
-	vector<uint32_t> PutSharedOUTGate(vector<uint32_t> in);
+        std::vector<uint32_t> PutSharedOUTGate(std::vector<uint32_t> in);
 
 	uint32_t PutINGate(e_sharing context, uint32_t nvals, uint32_t sharebitlen, e_role src, uint32_t rounds);
 
@@ -210,14 +211,14 @@ public:
 
 	uint32_t PutConstantGate(e_sharing context, UGATE_T val, uint32_t nvals, uint32_t sharebitlen);
 	uint32_t PutINVGate(uint32_t in);
-	uint32_t PutCONVGate(vector<uint32_t> in, uint32_t nrounds, e_sharing dst, uint32_t sharebitlen);
-	uint32_t PutCallbackGate(vector<uint32_t> in, uint32_t rounds, void (*callback)(GATE*, void*), void* infos, uint32_t nvals);
-	uint32_t PutTruthTableGate(vector<uint32_t> in, uint32_t rounds, uint32_t out_bits, uint64_t* truth_table);
-	uint32_t PutTruthTableMultiOutputGate(vector<uint32_t> in, uint32_t rounds, uint32_t out_bits, uint64_t* truth_table);
+	uint32_t PutCONVGate(std::vector<uint32_t> in, uint32_t nrounds, e_sharing dst, uint32_t sharebitlen);
+	uint32_t PutCallbackGate(std::vector<uint32_t> in, uint32_t rounds, void (*callback)(GATE*, void*), void* infos, uint32_t nvals);
+	uint32_t PutTruthTableGate(std::vector<uint32_t> in, uint32_t rounds, uint32_t out_bits, uint64_t* truth_table);
+	uint32_t PutTruthTableMultiOutputGate(std::vector<uint32_t> in, uint32_t rounds, uint32_t out_bits, uint64_t* truth_table);
 
 
-	uint32_t PutPrintValGate(vector<uint32_t> in, string infostr);
-	uint32_t PutAssertGate(vector<uint32_t> in, uint32_t bitlen, UGATE_T* assert_val);
+	uint32_t PutPrintValGate(std::vector<uint32_t> in, std::string infostr);
+	uint32_t PutAssertGate(std::vector<uint32_t> in, uint32_t bitlen, UGATE_T* assert_val);
 
 	uint32_t GetGateHead() {
 		return m_nNextFreeGate;
@@ -232,23 +233,23 @@ public:
 	}
 
 	//Export the constructed circuit in the Bristol circuit file format
-	void ExportCircuitInBristolFormat(vector<uint32_t> ingates_client, vector<uint32_t> ingates_server,
-			vector<uint32_t> outgates, const char* filename);
+	void ExportCircuitInBristolFormat(std::vector<uint32_t> ingates_client, std::vector<uint32_t> ingates_server,
+			std::vector<uint32_t> outgates, const char* filename);
 
 private:
 
 	inline void InitGate(GATE* gate, e_gatetype type);
 	inline void InitGate(GATE* gate, e_gatetype type, uint32_t ina);
 	inline void InitGate(GATE* gate, e_gatetype type, uint32_t ina, uint32_t inb);
-	inline void InitGate(GATE* gate, e_gatetype type, vector<uint32_t>& inputs);
+	inline void InitGate(GATE* gate, e_gatetype type, std::vector<uint32_t>& inputs);
 
 	inline uint32_t GetNumRounds(e_gatetype type, e_sharing context);
 	inline void MarkGateAsUsed(uint32_t gateid, uint32_t uses = 1);
 
-	void ExportGateInBristolFormat(uint32_t gateid, uint32_t& next_gate_id, vector<int>& gate_id_map,
-			vector<int>& constant_map, ofstream& outfile);
-	void CheckAndPropagateConstant(uint32_t gateid, uint32_t& next_gate_id, vector<int>& gate_id_map,
-			vector<int>& constant_map, ofstream& outfile);
+	void ExportGateInBristolFormat(uint32_t gateid, uint32_t& next_gate_id, std::vector<int>& gate_id_map,
+			std::vector<int>& constant_map, std::ofstream& outfile);
+	void CheckAndPropagateConstant(uint32_t gateid, uint32_t& next_gate_id, std::vector<int>& gate_id_map,
+			std::vector<int>& constant_map, std::ofstream& outfile);
 
 	GATE* m_pGates;
 	uint32_t m_nNextFreeGate;	// points to the current first unused gate

--- a/src/abycore/circuit/arithmeticcircuits.cpp
+++ b/src/abycore/circuit/arithmeticcircuits.cpp
@@ -18,6 +18,7 @@
 
 #include "arithmeticcircuits.h"
 
+using namespace std;
 void ArithmeticCircuit::Init() {
 	m_nMULs = 0;
 	m_nCONVGates = 0;

--- a/src/abycore/circuit/arithmeticcircuits.h
+++ b/src/abycore/circuit/arithmeticcircuits.h
@@ -190,7 +190,7 @@ public:
 	uint32_t PutOUTGate(uint32_t parent, e_role dst);
 	share* PutOUTGate(share* parent, e_role dst);
 
-	vector<uint32_t> PutSharedOUTGate(vector<uint32_t> parentids);
+        std::vector<uint32_t> PutSharedOUTGate(std::vector<uint32_t> parentids);
 	share* PutSharedOUTGate(share* parent);
 
 
@@ -201,54 +201,54 @@ public:
 
 
 	uint32_t PutINVGate(uint32_t parentid);
-	uint32_t PutCONVGate(vector<uint32_t> parentids);
+	uint32_t PutCONVGate(std::vector<uint32_t> parentids);
 
 	share* PutADDGate(share* ina, share* inb);
 
 	share* PutSUBGate(share* ina, share* inb);
-	share* PutANDGate(share* ina, share* inb) {
-		cerr << "AND not implemented in arithmetic sharing" << endl;
+	share* PutANDGate(share*, share*) {
+                std::cerr << "AND not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutXORGate(share* ina, share* inb) {
-		cerr << "XOR not implemented in arithmetic sharing" << endl;
+	share* PutXORGate(share*, share*) {
+          std::cerr << "XOR not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutSubGate(share* ina, share* inb) {
-		cerr << "Sub not implemented in arithmetic sharing" << endl;
+	share* PutSubGate(share*, share*) {
+		std::cerr << "Sub not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
 	share* PutMULGate(share* ina, share* inb);
 
-	share* PutGTGate(share* ina, share* inb) {
-		cerr << "GT not implemented in arithmetic sharing" << endl;
+	share* PutGTGate(share*, share*) {
+		std::cerr << "GT not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutEQGate(share* ina, share* inb) {
-		cerr << "EQ not implemented in arithmetic sharing" << endl;
+	share* PutEQGate(share*, share*) {
+		std::cerr << "EQ not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutMUXGate(share* ina, share* inb, share* sel) {
-		cerr << "MUX not implemented in arithmetic sharing" << endl;
+	share* PutMUXGate(share*, share*, share*) {
+		std::cerr << "MUX not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutY2BGate(share* ina) {
-		cerr << "Y2B not implemented in arithmetic sharing" << endl;
+	share* PutY2BGate(share*) {
+		std::cerr << "Y2B not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutB2YGate(share* ina) {
-		cerr << "B2Y not implemented in arithmetic sharing" << endl;
+	share* PutB2YGate(share*) {
+		std::cerr << "B2Y not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutA2YGate(share* ina) {
-		cerr << "A2Y not implemented in arithmetic sharing" << endl;
+	share* PutA2YGate(share*) {
+		std::cerr << "A2Y not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	share* PutANDVecGate(share* ina, share* inb) {
-		cerr << "ANDVec Gate not implemented in arithmetic sharing" << endl;
+	share* PutANDVecGate(share*, share*) {
+          std::cerr << "ANDVec Gate not implemented in arithmetic sharing" << std::endl;
 		return new arithshare(this);
 	}
-	uint32_t PutB2AGate(vector<uint32_t> ina);
+	uint32_t PutB2AGate(std::vector<uint32_t> ina);
 	share* PutB2AGate(share* ina);
 
 

--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "booleancircuits.h"
-
+using namespace std;
 void BooleanCircuit::Init() {
 	m_nShareBitLen = 1;
 	m_nNumANDSizes = 1;

--- a/src/abycore/circuit/booleancircuits.h
+++ b/src/abycore/circuit/booleancircuits.h
@@ -47,18 +47,18 @@ public:
 	void Reset();
 
 	uint32_t PutANDGate(uint32_t left, uint32_t right);
-	vector<uint32_t> PutANDGate(vector<uint32_t> inleft, vector<uint32_t> inright);
+	std::vector<uint32_t> PutANDGate(std::vector<uint32_t> inleft, std::vector<uint32_t> inright);
 	share* PutANDGate(share* ina, share* inb);
 
 	uint32_t PutVectorANDGate(uint32_t choiceinput, uint32_t vectorinput);
 
 	uint32_t PutXORGate(uint32_t left, uint32_t right);
-	vector<uint32_t> PutXORGate(vector<uint32_t> inleft, vector<uint32_t> inright);
+	std::vector<uint32_t> PutXORGate(std::vector<uint32_t> inleft, std::vector<uint32_t> inright);
 	share* PutXORGate(share* ina, share* inb);
 
 	uint32_t PutORGate(uint32_t a, uint32_t b);
 	share* PutORGate(share* a, share* b);
-	vector<uint32_t> PutORGate(vector<uint32_t> a, vector<uint32_t> b);
+	std::vector<uint32_t> PutORGate(std::vector<uint32_t> a, std::vector<uint32_t> b);
 
 	uint32_t PutINGate(e_role src);
 	template<class T> uint32_t PutINGate(T val);
@@ -205,10 +205,10 @@ public:
 	share* PutYaoSharedSIMDINGate(uint32_t nvals, yao_fields* keys, uint32_t bitlen);
 
 	uint32_t PutOUTGate(uint32_t parent, e_role dst);
-	vector<uint32_t> PutOUTGate(vector<uint32_t> parents, e_role dst);
+	std::vector<uint32_t> PutOUTGate(std::vector<uint32_t> parents, e_role dst);
 	share* PutOUTGate(share* parent, e_role dst);
 
-	vector<uint32_t> PutSharedOUTGate(vector<uint32_t> parents);
+	std::vector<uint32_t> PutSharedOUTGate(std::vector<uint32_t> parents);
 	share* PutSharedOUTGate(share* parent);
 
 	share* PutCONSGate(UGATE_T val, uint32_t bitlen);
@@ -242,7 +242,7 @@ public:
 		return m_nNumANDSizes;
 	}
 	;
-	vector<vector<vector<tt_lens_ctx> > > GetTTLens() {
+        std::vector<std::vector<std::vector<tt_lens_ctx> > > GetTTLens() {
 		//inptr = m_vTTlens;
 		return m_vTTlens;
 	}
@@ -260,59 +260,59 @@ public:
 	share* PutEQGate(share* ina, share* inb);
 	share* PutMUXGate(share* ina, share* inb, share* sel);
 
-	vector<uint32_t> PutMulGate(vector<uint32_t> a, vector<uint32_t> b, uint32_t resbitlen, bool depth_optimized = false, bool vector_ands = false);
+	std::vector<uint32_t> PutMulGate(std::vector<uint32_t> a, std::vector<uint32_t> b, uint32_t resbitlen, bool depth_optimized = false, bool vector_ands = false);
 
 
-	vector<uint32_t> PutAddGate(vector<uint32_t> left, vector<uint32_t> right, BOOL bCarry = FALSE);
+	std::vector<uint32_t> PutAddGate(std::vector<uint32_t> left, std::vector<uint32_t> right, BOOL bCarry = FALSE);
 	share* PutADDGate(share* ina, share* inb);
 
-	vector<uint32_t> PutSizeOptimizedAddGate(vector<uint32_t> left, vector<uint32_t> right, BOOL bCarry = FALSE);
-	vector<uint32_t> PutDepthOptimizedAddGate(vector<uint32_t> lefta, vector<uint32_t> right, BOOL bCARRY = FALSE, bool vector_ands = false);
-	vector<uint32_t> PutLUTAddGate(vector<uint32_t> lefta, vector<uint32_t> right, BOOL bCARRY = FALSE);
+	std::vector<uint32_t> PutSizeOptimizedAddGate(std::vector<uint32_t> left, std::vector<uint32_t> right, BOOL bCarry = FALSE);
+	std::vector<uint32_t> PutDepthOptimizedAddGate(std::vector<uint32_t> lefta, std::vector<uint32_t> right, BOOL bCARRY = FALSE, bool vector_ands = false);
+	std::vector<uint32_t> PutLUTAddGate(std::vector<uint32_t> lefta, std::vector<uint32_t> right, BOOL bCARRY = FALSE);
 
-	vector<vector<uint32_t> > PutCarrySaveGate(vector<uint32_t> a, vector<uint32_t> b, vector<uint32_t> c, uint32_t inbitlen, bool bCarry = FALSE);
-	vector<vector<uint32_t> > PutCSNNetwork(vector<vector<uint32_t> > ins);
+	std::vector<std::vector<uint32_t> > PutCarrySaveGate(std::vector<uint32_t> a, std::vector<uint32_t> b, std::vector<uint32_t> c, uint32_t inbitlen, bool bCarry = FALSE);
+	std::vector<std::vector<uint32_t> > PutCSNNetwork(std::vector<std::vector<uint32_t> > ins);
 
-	vector<uint32_t> PutSUBGate(vector<uint32_t> a, vector<uint32_t> b, uint32_t max_bitlen);
+	std::vector<uint32_t> PutSUBGate(std::vector<uint32_t> a, std::vector<uint32_t> b, uint32_t max_bitlen);
 	share* PutSUBGate(share* ina, share* inb);
-	vector<uint32_t> PutWideAddGate(vector<vector<uint32_t> > ins);
-	uint32_t PutGTGate(vector<uint32_t> a, vector<uint32_t> b);
-	uint32_t PutSizeOptimizedGTGate(vector<uint32_t> a, vector<uint32_t> b);
-	uint32_t PutDepthOptimizedGTGate(vector<uint32_t> a, vector<uint32_t> b);
-	uint32_t PutLUTGTGate(vector<uint32_t> a, vector<uint32_t> b);
+	std::vector<uint32_t> PutWideAddGate(std::vector<std::vector<uint32_t> > ins);
+	uint32_t PutGTGate(std::vector<uint32_t> a, std::vector<uint32_t> b);
+	uint32_t PutSizeOptimizedGTGate(std::vector<uint32_t> a, std::vector<uint32_t> b);
+	uint32_t PutDepthOptimizedGTGate(std::vector<uint32_t> a, std::vector<uint32_t> b);
+	uint32_t PutLUTGTGate(std::vector<uint32_t> a, std::vector<uint32_t> b);
 
-	uint32_t PutEQGate(vector<uint32_t> a, vector<uint32_t> b);
+	uint32_t PutEQGate(std::vector<uint32_t> a, std::vector<uint32_t> b);
 
 
 	share* PutANDVecGate(share* ina, share* inb);
-	vector<uint32_t> PutMUXGate(vector<uint32_t> a, vector<uint32_t> b, uint32_t s, BOOL vecand = true);
+	vector<uint32_t> PutMUXGate(std::vector<uint32_t> a, std::vector<uint32_t> b, uint32_t s, BOOL vecand = true);
 
 	share* PutVecANDMUXGate(share* a, share* b, share* s);
-	vector<uint32_t> PutVecANDMUXGate(vector<uint32_t> a, vector<uint32_t> b, vector<uint32_t> s);
+	std::vector<uint32_t> PutVecANDMUXGate(std::vector<uint32_t> a, std::vector<uint32_t> b, std::vector<uint32_t> s);
 	uint32_t PutVecANDMUXGate(uint32_t a, uint32_t b, uint32_t s);
-	uint32_t PutWideGate(e_gatetype type, vector<uint32_t> ins);
-	uint32_t PutLUTWideANDGate(vector<uint32_t> in);
+	uint32_t PutWideGate(e_gatetype type, std::vector<uint32_t> ins);
+	uint32_t PutLUTWideANDGate(std::vector<uint32_t> in);
 	share** PutCondSwapGate(share* a, share* b, share* s, BOOL vectorized);
-	vector<vector<uint32_t> > PutCondSwapGate(vector<uint32_t> a, vector<uint32_t> b, uint32_t s, BOOL vectorized);
-	vector<uint32_t> PutELM0Gate(vector<uint32_t> val, uint32_t b);
+	std::vector<std::vector<uint32_t> > PutCondSwapGate(std::vector<uint32_t> a, std::vector<uint32_t> b, uint32_t s, BOOL vectorized);
+	std::vector<uint32_t> PutELM0Gate(std::vector<uint32_t> val, uint32_t b);
 
-	vector<uint32_t> LShift(vector<uint32_t> val, uint32_t pos, uint32_t nvals = 1);
+	std::vector<uint32_t> LShift(std::vector<uint32_t> val, uint32_t pos, uint32_t nvals = 1);
 
 	uint32_t PutIdxGate(uint32_t r, uint32_t maxidx);
 
 	share* PutStructurizedCombinerGate(share* input, uint32_t pos_start, uint32_t pos_incr, uint32_t nvals);
-	uint32_t PutStructurizedCombinerGate(vector<uint32_t> input, uint32_t pos_start, uint32_t pos_incr, uint32_t nvals);
+	uint32_t PutStructurizedCombinerGate(std::vector<uint32_t> input, uint32_t pos_start, uint32_t pos_incr, uint32_t nvals);
 
-	uint32_t PutCallbackGate(vector<uint32_t> in, uint32_t rounds, void (*callback)(GATE*, void*), void* infos, uint32_t nvals);
+	uint32_t PutCallbackGate(std::vector<uint32_t> in, uint32_t rounds, void (*callback)(GATE*, void*), void* infos, uint32_t nvals);
 	share* PutCallbackGate(share* in, uint32_t rounds, void (*callback)(GATE*, void*), void* infos, uint32_t nvals);
 
-	uint32_t PutTruthTableGate(vector<uint32_t> in, uint32_t out_bits, uint64_t* ttable);
+	uint32_t PutTruthTableGate(std::vector<uint32_t> in, uint32_t out_bits, uint64_t* ttable);
 	share* PutTruthTableGate(share* in, uint64_t* ttable);
 
-	vector<uint32_t> PutTruthTableMultiOutputGate(vector<uint32_t> in, uint32_t out_bits, uint64_t* ttable);
+	std::vector<uint32_t> PutTruthTableMultiOutputGate(std::vector<uint32_t> in, uint32_t out_bits, uint64_t* ttable);
 	share* PutTruthTableMultiOutputGate(share* in, uint32_t out_bits, uint64_t* ttable);
-	vector<uint32_t> PutLUTGateFromFile(const string filename, vector<uint32_t> inputs);
-	share* PutLUTGateFromFile(const string filename, share* input);
+	std::vector<uint32_t> PutLUTGateFromFile(const std::string filename, std::vector<uint32_t> inputs);
+	share* PutLUTGateFromFile(const std::string filename, share* input);
 
 
 	share* PutY2BGate(share* ina);
@@ -323,25 +323,25 @@ public:
 	uint32_t PutY2BCONVGate(uint32_t parentid);
 	uint32_t PutB2YCONVGate(uint32_t parentid);
 	uint32_t PutYSwitchRolesGate(uint32_t parentid);
-	vector<uint32_t> PutY2BCONVGate(vector<uint32_t> parentid);
-	vector<uint32_t> PutB2YCONVGate(vector<uint32_t> parentid);
-	vector<uint32_t> PutYSwitchRolesGate(vector<uint32_t> parentid);
+	std::vector<uint32_t> PutY2BCONVGate(std::vector<uint32_t> parentid);
+	std::vector<uint32_t> PutB2YCONVGate(std::vector<uint32_t> parentid);
+	std::vector<uint32_t> PutYSwitchRolesGate(std::vector<uint32_t> parentid);
 
 
-	vector<uint32_t> PutA2YCONVGate(vector<uint32_t> parentid);
+	std::vector<uint32_t> PutA2YCONVGate(std::vector<uint32_t> parentid);
 	share* PutA2YGate(share* ina);
 
-	share* PutB2AGate(share* ina) {
+	share* PutB2AGate(share*) {
 		cerr << "B2A not available for Boolean circuits, please use Arithmetic circuits instead" << endl;
 		return new boolshare(0, this);
 	}
 
 	uint32_t PutINVGate(uint32_t parentid);
-	vector<uint32_t> PutINVGate(vector<uint32_t> parentid);
+	std::vector<uint32_t> PutINVGate(std::vector<uint32_t> parentid);
 	share* PutINVGate(share* parent);
 
 	share* PutMinGate(share** a, uint32_t nvals);
-	vector<uint32_t> PutMinGate(vector<vector<uint32_t> > a);
+	std::vector<uint32_t> PutMinGate(std::vector<std::vector<uint32_t> > a);
 
 	/**
 	 * \brief Floating point gate with one input
@@ -351,7 +351,7 @@ public:
 	 * \param nvals parallel instantiation
 	 * \return output wire IDs
 	 */
-	vector<uint32_t> PutFPGate(const string func, vector<uint32_t> inputs, uint8_t bitsize, uint32_t nvals = 1);
+	std::vector<uint32_t> PutFPGate(const std::string func, std::vector<uint32_t> inputs, uint8_t bitsize, uint32_t nvals = 1);
 
 	/**
 	 * \brief Floating point gate with two inputs
@@ -362,7 +362,7 @@ public:
 	 * \param nvals parallel instantiation
 	 * \return output wire IDs
 	 */
-	vector<uint32_t> PutFPGate(const string func, vector<uint32_t> ina, vector<uint32_t> inb, uint8_t bitsize, uint32_t nvals = 1);
+	std::vector<uint32_t> PutFPGate(const std::string func, std::vector<uint32_t> ina, std::vector<uint32_t> inb, uint8_t bitsize, uint32_t nvals = 1);
 
 	/**
 	 * \brief Add gate from a certain .aby file
@@ -370,22 +370,22 @@ public:
 	 * \param nvals parallel instantiation
 	 * \return output wire IDs
 	 */
-	vector<uint32_t> PutGateFromFile(const string filename, vector<uint32_t> inputs, uint32_t nvals = 1);
+	std::vector<uint32_t> PutGateFromFile(const std::string filename, std::vector<uint32_t> inputs, uint32_t nvals = 1);
 
 	/**
 	 * \brief Get the number of input bits for both parties that a given circuit file expects
 	 * \param the file name of the circuit
 	 * \return the number of input bits for both parties
 	 */
-	uint32_t GetInputLengthFromFile(const string filename);
+	uint32_t GetInputLengthFromFile(const std::string filename);
 
 	void PutMinIdxGate(share** vals, share** ids, uint32_t nvals, share** minval_shr, share** minid_shr);
-	void PutMinIdxGate(vector<vector<uint32_t> > vals, vector<vector<uint32_t> > ids,
-			vector<uint32_t>& minval, vector<uint32_t>& minid);
+	void PutMinIdxGate(std::vector<std::vector<uint32_t> > vals, std::vector<std::vector<uint32_t> > ids,
+			std::vector<uint32_t>& minval, std::vector<uint32_t>& minid);
 
 	void PutMaxIdxGate(share** vals, share** ids, uint32_t nvals, share** maxval_shr, share** maxid_shr);
-	void PutMaxIdxGate(vector<vector<uint32_t> > vals, vector<vector<uint32_t> > ids,
-			vector<uint32_t>& maxval, vector<uint32_t>& maxid);
+	void PutMaxIdxGate(std::vector<std::vector<uint32_t> > vals, std::vector<std::vector<uint32_t> > ids,
+			std::vector<uint32_t>& maxval, std::vector<uint32_t>& maxid);
 
 
 	void PutMultiMUXGate(share** Sa, share** Sb, share* sel, uint32_t nshares, share** Sout);
@@ -436,7 +436,7 @@ public:
          * @param carry_in optional carry in bit c (zero gate if not needed)
          * @return sum of values on wires a and b
          */
-    	share* PutADDChainGate(vector <uint32_t> a, vector <uint32_t> b, uint32_t carry_in);
+    	share* PutADDChainGate(std::vector <uint32_t> a, std::vector <uint32_t> b, uint32_t carry_in);
         
 
         /**
@@ -462,7 +462,7 @@ public:
          * @param to type to which value will be converted
          * @return wires of the converted value
          */
-        vector<uint32_t> PutConvTypeGate(vector<uint32_t> wires, ConvType* from, ConvType* to, uint32_t nvals = 1);
+        std::vector<uint32_t> PutConvTypeGate(std::vector<uint32_t> wires, ConvType* from, ConvType* to, uint32_t nvals = 1);
         
         /**
          * Converts unsigned integer to floating point number
@@ -471,7 +471,7 @@ public:
          * @param to type to which value will be converted
          * @return wires of the converted value
          */
-        vector<uint32_t> PutUint2FpGate(vector<uint32_t> wires, UINTType* from, FPType* to, uint32_t nvals = 1);
+        std::vector<uint32_t> PutUint2FpGate(std::vector<uint32_t> wires, UINTType* from, FPType* to, uint32_t nvals = 1);
         
         /**
          * Converts floating point to unsigned integer number
@@ -480,7 +480,7 @@ public:
          * @param to type to which value will be converted
          * @return wires of the converted value
          */
-        vector<uint32_t> PutFp2UintGate(vector<uint32_t> wires, FPType* from, UINTType* to);
+        std::vector<uint32_t> PutFp2UintGate(std::vector<uint32_t> wires, FPType* from, UINTType* to);
         
         /**
          * Computes Prefix Or operation, thus, zeros before first seen 1 and 1s after (e.g. 0010100 => 0011111).
@@ -494,7 +494,7 @@ public:
          * @param wires input value
          * @return value of prefix or
          */
-        vector<uint32_t> PutPreOrGate(vector<uint32_t> wires);
+        std::vector<uint32_t> PutPreOrGate(std::vector<uint32_t> wires);
         
         /**
          * Uses MUXs to shift bits of the value to the left.
@@ -509,7 +509,7 @@ public:
          * @param n number of bits to shift
          * @return shifted value
          */
-        vector<uint32_t> PutBarrelLeftShifterGate(vector<uint32_t> wires, vector<uint32_t> n, uint32_t nvals = 1);
+        std::vector<uint32_t> PutBarrelLeftShifterGate(std::vector<uint32_t> wires, std::vector<uint32_t> n, uint32_t nvals = 1);
         /**
          * Uses MUXs to shift bits of the value to the right.
          * @param input input value
@@ -523,7 +523,7 @@ public:
          * @param n number of bits to shift
          * @return shifted value
          */
-        vector<uint32_t> PutBarrelRightShifterGate(vector<uint32_t> wires, vector<uint32_t> n);
+        std::vector<uint32_t> PutBarrelRightShifterGate(std::vector<uint32_t> wires, std::vector<uint32_t> n);
         
         /**
          * Put floating point gate with one input
@@ -550,11 +550,11 @@ private:
 
 	void UpdateTruthTableSizes(uint32_t len, uint32_t gateid, uint32_t out_bits);
 
-	void PadWithLeadingZeros(vector<uint32_t> &a, vector<uint32_t> &b);
+	void PadWithLeadingZeros(std::vector<uint32_t> &a, std::vector<uint32_t> &b);
 
 	non_lin_vec_ctx* m_vANDs;
 	//first dimension: circuit depth, second dimension: num-inputs, third dimension: out_bitlen
-	vector<vector<vector<tt_lens_ctx> > > m_vTTlens;
+	std::vector<std::vector<std::vector<tt_lens_ctx> > > m_vTTlens;
 
 	uint32_t m_nNumANDSizes;
 	//uint32_t m_nNumTTSizes;

--- a/src/abycore/circuit/circuit.cpp
+++ b/src/abycore/circuit/circuit.cpp
@@ -18,6 +18,8 @@
 */
 #include "circuit.h"
 
+using namespace std;
+
 void Circuit::Init() {
 
 	m_pGates = m_cCircuit->Gates();
@@ -41,7 +43,6 @@ void Circuit::Init() {
 	//m_vNonLinOnLayer.min_depth = 0;
 	//m_vNonLinOnLayer.num_on_layer = (uint32_t*) calloc(m_vNonLinOnLayer.max_depth, sizeof(uint32_t));
 }
-;
 
 void Circuit::Cleanup() {
 	//TODO implement
@@ -54,7 +55,6 @@ void Circuit::Cleanup() {
 	//m_vInputBits.clear();
 	//m_vOutputBits.clear();
 }
-;
 
 void Circuit::Reset() {
 	m_nMaxDepth = 0;

--- a/src/abycore/circuit/circuit.h
+++ b/src/abycore/circuit/circuit.h
@@ -22,6 +22,11 @@
 
 #include "abycircuit.h"
 
+#include <deque>
+#include <iostream>
+#include <string>
+#include <vector>
+
 class share;
 class boolshare;
 class arithshare;
@@ -77,7 +82,7 @@ public:
 		\param lvl Required level of local queue.
 		\return Local queue on the required level
 	*/
-	deque<uint32_t> GetLocalQueueOnLvl(uint32_t lvl) {
+        std::deque<uint32_t> GetLocalQueueOnLvl(uint32_t lvl) {
 
 		if (lvl < m_vLocalQueueOnLvl.size())
 			return m_vLocalQueueOnLvl[lvl];
@@ -90,18 +95,19 @@ public:
 		\param lvl Required level of interactive queue.
 		\return Interactive queue on the required level
 	*/
-	deque<uint32_t> GetInteractiveQueueOnLvl(uint32_t lvl) {
-		if (lvl < m_vInteractiveQueueOnLvl.size())
+        std::deque<uint32_t> GetInteractiveQueueOnLvl(uint32_t lvl) {
+		if (lvl < m_vInteractiveQueueOnLvl.size()) {
 			return m_vInteractiveQueueOnLvl[lvl];
-		else
+                } else { 
 			return EMPTYQUEUE;
+                }
 	}
 
 	/*
 	 * print the number of interactive operations for each layer
 	 */
 	void PrintInteractiveQueues(){
-		vector<string> sharingnames {"GMW", "Yao", "Arith", "Yao_Rev", "SPLUT"};
+          std::vector<std::string> sharingnames {"GMW", "Yao", "Arith", "Yao_Rev", "SPLUT"};
 
 		std::cout << "Interactive Queue Sizes " << sharingnames[this->m_eContext] << std::endl;
 
@@ -149,7 +155,7 @@ public:
 		\param	party Party role based on which the Input gates are returned.
 		\return Input gates for the provided party
 	*/
-	deque<uint32_t> GetInputGatesForParty(e_role party) {
+	std::deque<uint32_t> GetInputGatesForParty(e_role party) {
 		return m_vInputGates[party];
 	}
 
@@ -158,7 +164,7 @@ public:
 		\param	party Party role based on which the Output gates are returned.
 		\return Output gates for the provided party
 	*/
-	deque<uint32_t> GetOutputGatesForParty(e_role party) {
+        std::deque<uint32_t> GetOutputGatesForParty(e_role party) {
 		return m_vOutputGates[party];
 	}
 
@@ -282,7 +288,7 @@ public:
 	virtual share* PutTruthTableMultiOutputGate(share* in, uint32_t out_bits, uint64_t* ttable) = 0;
 
 
-	share* PutPrintValueGate(share* in, string helpstr);
+	share* PutPrintValueGate(share* in, std::string helpstr);
 	//TODO: AssertGate and SIMDAssertGate need interfaces for all types as INGate and SIMDINGates
 	share* PutAssertGate(share* in, uint64_t* assert_val, uint32_t bitlen);
 	share* PutAssertGate(share* in, uint32_t* assert_val, uint32_t bitlen);
@@ -367,41 +373,41 @@ public:
 
 
 	uint32_t PutRepeaterGate(uint32_t input, uint32_t nvals);
-	uint32_t PutCombinerGate(vector<uint32_t> input);
-	uint32_t PutCombineAtPosGate(vector<uint32_t> input, uint32_t pos);
+	uint32_t PutCombinerGate(std::vector<uint32_t> input);
+	uint32_t PutCombineAtPosGate(std::vector<uint32_t> input, uint32_t pos);
 	uint32_t PutSubsetGate(uint32_t input, uint32_t* posids, uint32_t nvals_out, bool copy_posids = true);
-	uint32_t PutPermutationGate(vector<uint32_t> input, uint32_t* positions);
-	vector<uint32_t> PutSplitterGate(uint32_t input);
+	uint32_t PutPermutationGate(std::vector<uint32_t> input, uint32_t* positions);
+        std::vector<uint32_t> PutSplitterGate(uint32_t input);
 
 
 	//Templates may not be virtual, hence use dummy functions
 	template<class T> uint32_t PutINGate(T val) {
-		cout << "IN gate not implemented in super-class, stopping!" << endl;
+                std::cout << "IN gate not implemented in super-class, stopping!" << std::endl;
 		return -1;
 	}
 
 	template<class T> uint32_t PutINGate(T val, e_role role) {
-		cout << "IN gate not implemented in super-class, stopping!" << endl;
+		std::cout << "IN gate not implemented in super-class, stopping!" << std::endl;
 		return -1;
 	}
 
 	template<class T> uint32_t PutSharedINGate(T val) {
-		cout << "IN gate not implemented in super-class, stopping!" << endl;
+		std::cout << "IN gate not implemented in super-class, stopping!" << std::endl;
 		return -1;
 	}
 
 	template<class T> uint32_t PutSIMDINGate(uint32_t nvals, T val) {
-		cout << "IN gate not implemented in super-class, stopping!" << endl;
+		std::cout << "IN gate not implemented in super-class, stopping!" << std::endl;
 		return -1;
 	}
 
 	template<class T> uint32_t PutSIMDINGate(uint32_t nvals, T val, e_role role) {
-		cout << "IN gate not implemented in super-class, stopping!" << endl;
+		std::cout << "IN gate not implemented in super-class, stopping!" << std::endl;
 		return -1;
 	}
 
 	template<class T> uint32_t PutSharedSIMDINGate(uint32_t nvals, T val) {
-		cout << "IN gate not implemented in super-class, stopping!" << endl;
+		std::cout << "IN gate not implemented in super-class, stopping!" << std::endl;
 		return -1;
 	}
 
@@ -462,12 +468,12 @@ protected:
 	e_circuit m_eCirctype;
 	uint32_t m_nMaxDepth;
 
-	vector<deque<uint32_t> > m_vLocalQueueOnLvl; //for locally evaluatable gates, first dimension is the level of the gates, second dimension presents the queue on which the gateids are put
-	vector<deque<uint32_t> > m_vInteractiveQueueOnLvl; //for gates that need interaction, first dimension is the level of the gates, second dimension presents the queue on which the gateids are put
-	vector<deque<uint32_t> > m_vInputGates;				//input gates for the parties
-	vector<deque<uint32_t> > m_vOutputGates;				//input gates for the parties
-	vector<uint32_t> m_vInputBits;				//number of input bits for the parties
-	vector<uint32_t> m_vOutputBits;				//number of output bits for the parties
+	std::vector<std::deque<uint32_t> > m_vLocalQueueOnLvl; //for locally evaluatable gates, first dimension is the level of the gates, second dimension presents the queue on which the gateids are put
+	std::vector<std::deque<uint32_t> > m_vInteractiveQueueOnLvl; //for gates that need interaction, first dimension is the level of the gates, second dimension presents the queue on which the gateids are put
+	std::vector<std::deque<uint32_t> > m_vInputGates;				//input gates for the parties
+	std::vector<std::deque<uint32_t> > m_vOutputGates;				//input gates for the parties
+	std::vector<uint32_t> m_vInputBits;				//number of input bits for the parties
+	std::vector<uint32_t> m_vOutputBits;				//number of output bits for the parties
 
 	uint32_t ncombgates;
 	uint32_t npermgates;
@@ -481,17 +487,17 @@ protected:
 	uint32_t m_nGates;
 	uint32_t m_nRoundsAND;
 	uint32_t m_nRoundsXOR;
-	vector<uint32_t> m_nRoundsIN;
-	vector<uint32_t> m_nRoundsOUT;
+	std::vector<uint32_t> m_nRoundsIN;
+	std::vector<uint32_t> m_nRoundsOUT;
 
-	const deque<uint32_t> EMPTYQUEUE;
+	const std::deque<uint32_t> EMPTYQUEUE;
 
 	//non_lin_on_layers m_vNonLinOnLayer;
 };
 
 
 share* create_new_share(uint32_t size, Circuit* circ);
-share* create_new_share(vector<uint32_t> vals, Circuit* circ);
+share* create_new_share(std::vector<uint32_t> vals, Circuit* circ);
 
 #include "share.h"
 

--- a/src/abycore/circuit/share.cpp
+++ b/src/abycore/circuit/share.cpp
@@ -20,6 +20,7 @@
 
 #include "share.h"
 
+using namespace std;
 
 /* =========================== Methods for the share class =========================== */
 

--- a/src/abycore/circuit/share.h
+++ b/src/abycore/circuit/share.h
@@ -27,7 +27,7 @@ public:
 	/** Constructor overloaded with shared length and circuit.*/
 	share(uint32_t sharelen, Circuit* circ);
 	/** Constructor overloaded with gates and circuit.*/
-	share(vector<uint32_t> gates, Circuit* circ);
+	share(std::vector<uint32_t> gates, Circuit* circ);
 	/**
 	 Initialise Function
 	 \param circ 		Ciruit object.
@@ -40,7 +40,7 @@ public:
 	}
 	;
 
-	vector<uint32_t> get_wires() {
+        std::vector<uint32_t> get_wires() {
 		return m_ngateids;
 	}
 	;
@@ -50,7 +50,7 @@ public:
 
 	void set_wire_id(uint32_t posid, uint32_t wireid);
 
-	void set_wire_ids(vector<uint32_t> wires) {
+	void set_wire_ids(std::vector<uint32_t> wires) {
 		m_ngateids = wires;
 	}
 	;
@@ -106,7 +106,7 @@ public:
 	virtual void get_clear_value_vec(uint64_t** vec, uint32_t *bitlen, uint32_t *nvals) = 0;
 
 protected:
-	vector<uint32_t> m_ngateids;
+        std::vector<uint32_t> m_ngateids;
 	Circuit* m_ccirc;
 	uint32_t m_nmaxbitlen;
 };
@@ -121,7 +121,7 @@ public:
 	}
 	;
 	/** Constructor overloaded with gates and circuit.*/
-	boolshare(vector<uint32_t> gates, Circuit* circ) :
+	boolshare(std::vector<uint32_t> gates, Circuit* circ) :
 			share(gates, circ) {
 	}
 	;
@@ -165,7 +165,7 @@ public:
 	}
 	;
 	/** Constructor overloaded with gates and circuit.*/
-	arithshare(vector<uint32_t> gates, Circuit* circ) :
+	arithshare(std::vector<uint32_t> gates, Circuit* circ) :
 			share(gates, circ) {
 	}
 	;

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -18,6 +18,8 @@
 
 #include "arithsharing.h"
 
+using namespace std;
+
 template<typename T>
 void ArithSharing<T>::Init() {
 	m_nMTs = 0;

--- a/src/abycore/sharing/arithsharing.h
+++ b/src/abycore/sharing/arithsharing.h
@@ -63,8 +63,8 @@ public:
 
 	void InstantiateGate(GATE* gate);
 
-	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
-	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
+	void GetDataToSend(std::vector<BYTE*>& sendbuf, std::vector<uint64_t>& bytesize);
+	void GetBuffersToReceive(std::vector<BYTE*>& rcvbuf, std::vector<uint64_t>& rcvbytes);
 
 	uint32_t AssignInput(CBitVector& input);
 	uint32_t GetOutput(CBitVector& out);
@@ -118,12 +118,12 @@ private:
 
 	uint64_t m_nTypeBitMask;
 
-	vector<uint32_t> m_vMTStartIdx;
-	vector<uint32_t> m_vMTIdx;
-	vector<GATE*> m_vMULGates;
-	vector<GATE*> m_vInputShareGates;
-	vector<GATE*> m_vOutputShareGates;
-	vector<GATE*> m_vCONVGates;
+        std::vector<uint32_t> m_vMTStartIdx;
+        std::vector<uint32_t> m_vMTIdx;
+        std::vector<GATE*> m_vMULGates;
+        std::vector<GATE*> m_vInputShareGates;
+        std::vector<GATE*> m_vOutputShareGates;
+        std::vector<GATE*> m_vCONVGates;
 
 	uint32_t m_nInputShareSndCtr;
 	uint32_t m_nOutputShareSndCtr;
@@ -131,16 +131,16 @@ private:
 	uint32_t m_nInputShareRcvCtr;
 	uint32_t m_nOutputShareRcvCtr;
 
-	vector<CBitVector> m_vA; //Dim 1 for all pairs of sender / receiver, Dim 2 for MTs of different bitlengths as sender / receiver
-	vector<CBitVector> m_vB; //value B of a multiplication triple
-	vector<CBitVector> m_vS; // temporary value for the computation of the multiplication triples
-	vector<CBitVector> m_vC; // value C of a multiplication triple
-	vector<CBitVector> m_vD_snd; //Stores the D values (x ^ a) between an input and the multiplication value a
-	vector<CBitVector> m_vE_snd; //Stores the E values (y ^ b) between the other input and the multiplication value b
-	vector<CBitVector> m_vD_rcv;
-	vector<CBitVector> m_vE_rcv;
-	vector<CBitVector> m_vResA;
-	vector<CBitVector> m_vResB;
+        std::vector<CBitVector> m_vA; //Dim 1 for all pairs of sender / receiver, Dim 2 for MTs of different bitlengths as sender / receiver
+        std::vector<CBitVector> m_vB; //value B of a multiplication triple
+        std::vector<CBitVector> m_vS; // temporary value for the computation of the multiplication triples
+        std::vector<CBitVector> m_vC; // value C of a multiplication triple
+        std::vector<CBitVector> m_vD_snd; //Stores the D values (x ^ a) between an input and the multiplication value a
+        std::vector<CBitVector> m_vE_snd; //Stores the E values (y ^ b) between the other input and the multiplication value b
+        std::vector<CBitVector> m_vD_rcv;
+        std::vector<CBitVector> m_vE_rcv;
+        std::vector<CBitVector> m_vResA;
+        std::vector<CBitVector> m_vResB;
 
 	CBitVector m_vInputShareSndBuf;
 	CBitVector m_vOutputShareSndBuf;
@@ -151,7 +151,7 @@ private:
 	CBitVector m_vConvShareSndBuf;
 	CBitVector m_vConvShareRcvBuf;
 
-	vector<CBitVector> m_vConversionMasks;
+        std::vector<CBitVector> m_vConversionMasks;
 
 	CBitVector m_vConversionRandomness;
 

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -17,6 +17,8 @@
  */
 #include "boolsharing.h"
 
+using namespace std;
+
 void BoolSharing::Init() {
 
 	m_nTotalNumMTs = 0;

--- a/src/abycore/sharing/boolsharing.h
+++ b/src/abycore/sharing/boolsharing.h
@@ -74,8 +74,8 @@ public:
 
 	inline void InstantiateGate(GATE* gate);
 
-	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
-	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
+	void GetDataToSend(vector<BYTE*>& sendbuf, std::vector<uint64_t>& bytesize);
+	void GetBuffersToReceive(std::vector<BYTE*>& rcvbuf, std::vector<uint64_t>& rcvbytes);
 
 	void EvaluateSIMDGate(uint32_t gateid);
 
@@ -97,7 +97,7 @@ public:
 	;
 
 	void Reset();
-	vector<uint32_t> GetNumOTs() {
+	std::vector<uint32_t> GetNumOTs() {
 		return m_nNumMTs;
 	}
 	;
@@ -113,15 +113,15 @@ private:
 
 	uint32_t m_nTotalNumMTs;
 	uint32_t m_nOPLUT_Tables;
-	vector<uint32_t> m_nNumMTs;
+	std::vector<uint32_t> m_nNumMTs;
 	uint32_t m_nXORGates;
 
 	XORMasking *fMaskFct; // = new XORMasking(1);
-	vector<uint32_t> m_vMTStartIdx;
-	vector<uint32_t> m_vMTIdx;
-	vector<vector<uint32_t> > m_vANDGates;
-	vector<uint32_t> m_vInputShareGates;
-	vector<uint32_t> m_vOutputShareGates;
+	std::vector<uint32_t> m_vMTStartIdx;
+	std::vector<uint32_t> m_vMTIdx;
+	std::vector<std::vector<uint32_t> > m_vANDGates;
+	std::vector<uint32_t> m_vInputShareGates;
+	std::vector<uint32_t> m_vOutputShareGates;
 
 	uint32_t m_nInputShareSndSize;
 	uint32_t m_nOutputShareSndSize;
@@ -132,31 +132,31 @@ private:
 	uint32_t m_nNumANDSizes;
 
 
-	vector<CBitVector> m_vA; //Dim 1 for all pairs of sender / receiver, Dim 2 for MTs of different bitlengths as sender / receiver
-	vector<CBitVector> m_vB; //value B of a multiplication triple
-	vector<CBitVector> m_vS; // temporary value for the computation of the multiplication triples
-	vector<CBitVector> m_vC; // value C of a multiplication triple
-	vector<CBitVector> m_vD_snd; //Stores the D values (x ^ a) between an input and the multiplication value a
-	vector<CBitVector> m_vE_snd; //Stores the E values (y ^ b) between the other input and the multiplication value b
-	vector<CBitVector> m_vD_rcv;
-	vector<CBitVector> m_vE_rcv;
-	vector<CBitVector> m_vResA;
-	vector<CBitVector> m_vResB;
+	std::vector<CBitVector> m_vA; //Dim 1 for all pairs of sender / receiver, Dim 2 for MTs of different bitlengths as sender / receiver
+	std::vector<CBitVector> m_vB; //value B of a multiplication triple
+	std::vector<CBitVector> m_vS; // temporary value for the computation of the multiplication triples
+	std::vector<CBitVector> m_vC; // value C of a multiplication triple
+	std::vector<CBitVector> m_vD_snd; //Stores the D values (x ^ a) between an input and the multiplication value a
+	std::vector<CBitVector> m_vE_snd; //Stores the E values (y ^ b) between the other input and the multiplication value b
+	std::vector<CBitVector> m_vD_rcv;
+	std::vector<CBitVector> m_vE_rcv;
+	std::vector<CBitVector> m_vResA;
+	std::vector<CBitVector> m_vResB;
 	non_lin_vec_ctx* m_vANDs;
 
 	//multiplication triple values A, B and C for use in KK OT ext. Are later written to m_vA, m_vB and mvC. m_vKKS is used for temporary results
-	vector<CBitVector> m_vKKA;
-	vector<CBitVector> m_vKKB;
-	vector<CBitVector> m_vKKC;
-	vector<CBitVector*> m_vKKS;
-	vector<CBitVector*> m_vKKChoices;
+	std::vector<CBitVector> m_vKKA;
+	std::vector<CBitVector> m_vKKB;
+	std::vector<CBitVector> m_vKKC;
+	std::vector<CBitVector*> m_vKKS;
+	std::vector<CBitVector*> m_vKKChoices;
 
 	//Values that are needed for the OP-LUT protocol. The different dimensions correspond to the different input sizes and output sizes of the LUTs
-	map<uint64_t, op_lut_ctx*> 	m_vOP_LUT_data; //maps input and output bit-lengths to array indices for the m_vOP_LUT protocol
-	map<uint64_t, CBitVector*> 	m_vOP_LUT_SndSelOpeningBuf; //maps input and output bit-lengths to a send buffer which stores the selective openings
-	map<uint64_t, CBitVector*> 	m_vOP_LUT_RecSelOpeningBuf; //maps input and output bit-lengths to a receive buffer stores the received selective openings
-	map<uint64_t, uint64_t>		m_vOP_LUT_SelOpeningBitCtr; //Counts the bits in m_vOP_LUT_SndSelOpeningBuf to be send and in m_vOP_LUT_RecSelOpeningBuf to be received this round
-	map<uint64_t, vector<uint32_t> > m_vOPLUTGates;
+	std::map<uint64_t, op_lut_ctx*> 	m_vOP_LUT_data; //maps input and output bit-lengths to array indices for the m_vOP_LUT protocol
+	std::map<uint64_t, CBitVector*> 	m_vOP_LUT_SndSelOpeningBuf; //maps input and output bit-lengths to a send buffer which stores the selective openings
+	std::map<uint64_t, CBitVector*> 	m_vOP_LUT_RecSelOpeningBuf; //maps input and output bit-lengths to a receive buffer stores the received selective openings
+	std::map<uint64_t, uint64_t>		m_vOP_LUT_SelOpeningBitCtr; //Counts the bits in m_vOP_LUT_SndSelOpeningBuf to be send and in m_vOP_LUT_RecSelOpeningBuf to be received this round
+	std::map<uint64_t, std::vector<uint32_t> > m_vOPLUTGates;
 
 
 

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -17,6 +17,8 @@
  */
 #include "sharing.h"
 
+using namespace std;
+
 void Sharing::EvaluateCallbackGate(uint32_t gateid) {
 	GATE* gate = m_pGates + gateid;
 	void (*callback)(GATE*, void*) = gate->gs.cbgate.callback;

--- a/src/abycore/sharing/sharing.h
+++ b/src/abycore/sharing/sharing.h
@@ -119,13 +119,13 @@ public:
 	 \param 	sendbuf 	sender buffer
 	 \param 	bytesize	data size
 	 */
-	virtual void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize) = 0;
+	virtual void GetDataToSend(std::vector<BYTE*>& sendbuf, std::vector<uint64_t>& bytesize) = 0;
 	/**
 	 Method for receiving the data.
 	 \param 	rsvbuf 		receiver buffer
 	 \param 	rcvsize		data size
 	 */
-	virtual void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes) = 0;
+	virtual void GetBuffersToReceive(std::vector<BYTE*>& rcvbuf, std::vector<uint64_t>& rcvbytes) = 0;
 	/**
 	 Method for Instantiating a gate
 	 \param gate 		Input gate

--- a/src/abycore/sharing/splut.cpp
+++ b/src/abycore/sharing/splut.cpp
@@ -17,6 +17,7 @@
  */
 #include "splut.h"
 
+using namespace std;
 void SetupLUT::Init() {
 
 	uint32_t otNs = 9;

--- a/src/abycore/sharing/splut.h
+++ b/src/abycore/sharing/splut.h
@@ -85,8 +85,8 @@ public:
 
 	inline void InstantiateGate(GATE* gate);
 
-	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
-	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
+	void GetDataToSend(std::vector<BYTE*>& sendbuf, std::vector<uint64_t>& bytesize);
+	void GetBuffersToReceive(std::vector<BYTE*>& rcvbuf, std::vector<uint64_t>& rcvbytes);
 
 	void EvaluateSIMDGate(uint32_t gateid);
 
@@ -127,10 +127,10 @@ private:
 	uint64_t m_nTotalTTs;
 
 	XORMasking *fMaskFct;
-	vector<vector<uint32_t> > m_vTTGates;
+	std::vector<std::vector<uint32_t> > m_vTTGates;
 
-	vector<uint32_t> m_vInputShareGates;
-	vector<uint32_t> m_vOutputShareGates;
+	std::vector<uint32_t> m_vInputShareGates;
+	std::vector<uint32_t> m_vOutputShareGates;
 
 	uint32_t m_nInputShareSndSize;
 	uint32_t m_nOutputShareSndSize;
@@ -142,47 +142,47 @@ private:
 
 	//non_lin_vec_ctx* m_vANDs;
 	//first dimension is for server / client, second dimension is for ins, third dimension is for outs
-	vector<vector<vector<tt_lens_ctx> > > m_vNOTs;
+	std::vector<std::vector<std::vector<tt_lens_ctx> > > m_vNOTs;
 
-	vector<vector<uint32_t> > m_vOutBitMapping;
+	std::vector<std::vector<uint32_t> > m_vOutBitMapping;
 
 
 	CBitVector m_vInputShareSndBuf;
 	CBitVector m_vOutputShareSndBuf;
 
 	//information on updated choice bits from the OT
-	vector<vector<CBitVector*> > m_vChoiceUpdateSndBuf;
-	vector<vector<uint32_t> > m_nChoiceUpdateSndCtr;
-	vector<vector<CBitVector*> > m_vChoiceUpdateRcvBuf;
-	vector<vector<uint32_t> > m_nChoiceUpdateRcvCtr;
+	std::vector<std::vector<CBitVector*> > m_vChoiceUpdateSndBuf;
+	std::vector<std::vector<uint32_t> > m_nChoiceUpdateSndCtr;
+	std::vector<std::vector<CBitVector*> > m_vChoiceUpdateRcvBuf;
+	std::vector<std::vector<uint32_t> > m_nChoiceUpdateRcvCtr;
 
 	//information on updated masks from the OT
-	vector<vector<CBitVector*> > m_vMaskUpdateSndBuf;
-	vector<vector<uint32_t> > m_nMaskUpdateSndCtr;
-	vector<vector<CBitVector*> > m_vMaskUpdateRcvBuf;
-	vector<vector<uint32_t> > m_nMaskUpdateRcvCtr;
+	std::vector<std::vector<CBitVector*> > m_vMaskUpdateSndBuf;
+	std::vector<std::vector<uint32_t> > m_nMaskUpdateSndCtr;
+	std::vector<std::vector<CBitVector*> > m_vMaskUpdateRcvBuf;
+	std::vector<std::vector<uint32_t> > m_nMaskUpdateRcvCtr;
 
 
-	vector<uint8_t*> m_vSndBufStash;
-	vector<uint64_t> m_vSndBytesStash;
+	std::vector<uint8_t*> m_vSndBufStash;
+	std::vector<uint64_t> m_vSndBytesStash;
 
 	CBitVector m_vInputShareRcvBuf;
 	CBitVector m_vOutputShareRcvBuf;
 
 	BooleanCircuit* m_cBoolCircuit;
 
-	vector<vector<CBitVector**> > m_vPreCompOTX;
+	std::vector<std::vector<CBitVector**> > m_vPreCompOTX;
 
-	vector<vector<CBitVector*> > m_vPreCompOTMasks;
-	vector<vector<uint32_t> > m_vPreCompMaskIdx;
+	std::vector<std::vector<CBitVector*> > m_vPreCompOTMasks;
+	std::vector<std::vector<uint32_t> > m_vPreCompMaskIdx;
 
-	vector<vector<CBitVector*> > m_vPreCompOTC;
-	vector<vector<uint32_t> >m_vPreCompChoiceIdx;
-	vector<vector<CBitVector*> > m_vPreCompOTR;
+	std::vector<std::vector<CBitVector*> > m_vPreCompOTC;
+	std::vector<std::vector<uint32_t> >m_vPreCompChoiceIdx;
+	std::vector<std::vector<CBitVector*> > m_vPreCompOTR;
 
 
-	vector<vector<CBitVector*> > m_vTableRnd;
-	vector<vector<uint32_t> > m_nTableRndIdx;
+	std::vector<std::vector<CBitVector*> > m_vTableRnd;
+	std::vector<std::vector<uint32_t> > m_nTableRndIdx;
 
 	double t_snd, t_rcv;
 

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -16,7 +16,7 @@
  \brief		Yao Client Sharing class implementation.
  */
 #include "yaoclientsharing.h"
-
+using namespace std;
 void YaoClientSharing::InitClient() {
 
 	m_nChoiceBitCtr = 0;

--- a/src/abycore/sharing/yaoclientsharing.h
+++ b/src/abycore/sharing/yaoclientsharing.h
@@ -54,8 +54,8 @@ public:
 
 	void InstantiateGate(GATE* gate);
 
-	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
-	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
+	void GetDataToSend(std::vector<BYTE*>& sendbuf, std::vector<uint64_t>& bytesize);
+	void GetBuffersToReceive(std::vector<BYTE*>& rcvbuf, std::vector<uint64_t>& rcvbytes);
 
 	uint32_t AssignInput(CBitVector& input);
 	uint32_t GetOutput(CBitVector& out);
@@ -82,17 +82,17 @@ private:
 	uint64_t m_nClientOUTBitCtr; /**< Client Output Bit Counter.*/
 
 	CBitVector m_vServerKeyRcvBuf; /**< Server Key Receiver Buffer*/
-	vector<CBitVector> m_vClientKeyRcvBuf; /**< Client Key Receiver Buffer*/
+	std::vector<CBitVector> m_vClientKeyRcvBuf; /**< Client Key Receiver Buffer*/
 
 	uint32_t m_nGarbledCircuitRcvCtr;/**< Garbled Circuit Receiver Counter*/
 
 	CBitVector m_vOutputShareRcvBuf;/**< Output Share Receiver Buffer.*/
 	CBitVector m_vOutputShareSndBuf;/**< Output Share Sender Buffer*/
 
-	vector<uint32_t> m_vClientSendCorrectionGates; /**< Client send correction gates.*/
-	vector<uint32_t> m_vClientRcvInputKeyGates; /**< Client receives input key gates.*/
+	std::vector<uint32_t> m_vClientSendCorrectionGates; /**< Client send correction gates.*/
+	std::vector<uint32_t> m_vClientRcvInputKeyGates; /**< Client receives input key gates.*/
 
-	vector<uint32_t> m_vServerInputGates; /**< Server Input gates.*/
+	std::vector<uint32_t> m_vServerInputGates; /**< Server Input gates.*/
 
 	CBitVector m_vROTSndBuf;/**< __________________*/
 	uint32_t m_vROTCtr;/**< __________________*/

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -18,6 +18,10 @@
 
 #include "yaoserversharing.h"
 
+using std::vector;
+using std::cout;
+using std::endl;
+
 void YaoServerSharing::InitServer() {
 
 	//Allocate memory that is needed when generating the garbled tables

--- a/src/abycore/sharing/yaoserversharing.h
+++ b/src/abycore/sharing/yaoserversharing.h
@@ -59,8 +59,8 @@ public:
 
 	void InstantiateGate(GATE* gate);
 
-	void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize);
-	void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes);
+	void GetDataToSend(std::vector<BYTE*>& sendbuf, std::vector<uint64_t>& bytesize);
+	void GetBuffersToReceive(std::vector<BYTE*>& rcvbuf, std::vector<uint64_t>& rcvbytes);
 
 	uint32_t AssignInput(CBitVector& input);
 	uint32_t GetOutput(CBitVector& out);
@@ -77,14 +77,14 @@ private:
 	//Permutation bits for the servers input keys
 	CBitVector m_vPermBits; /**< _____________*/
 	//Random values from output of ot extension
-	vector<CBitVector> m_vROTMasks; /**< Masks_______________*/
+	std::vector<CBitVector> m_vROTMasks; /**< Masks_______________*/
 	uint32_t m_nClientInputKexIdx; /**< Client __________*/
 	uint32_t m_nClientInputKeyCtr; /**< Client __________*/
 
 	uint64_t m_nGarbledTableSndCtr;
 
 	CBitVector m_vServerKeySndBuf; /**< Server Key Sender Buffer*/
-	vector<CBitVector> m_vClientKeySndBuf; /**< Client Key Sender Buffer*/
+	std::vector<CBitVector> m_vClientKeySndBuf; /**< Client Key Sender Buffer*/
 	CBitVector m_vClientROTRcvBuf; /**< Client ______________*/
 
 	//vector<CBitVector> m_vClientConversionKeySndBuf;
@@ -93,7 +93,7 @@ private:
 	CBitVector m_vOutputShareSndBuf; /**< Output Share Sender Buffer.*/
 	CBitVector m_vOutputShareRcvBuf; /**< Output Share Receiver Buffer.*/
 
-	vector<GATE*> m_vServerOutputGates; /**< Server Output Gates*/
+	std::vector<GATE*> m_vServerOutputGates; /**< Server Output Gates*/
 
 	uint32_t m_nOutputShareRcvCtr; /**< Output Share Receiver Counter*/
 
@@ -110,7 +110,7 @@ private:
 	uint8_t* m_bTmpBuf;
 	//CBitVector
 
-	vector<uint32_t> m_vClientInputGate; /**< _____________*/
+	std::vector<uint32_t> m_vClientInputGate; /**< _____________*/
 	deque<input_gate_val_t> m_vPreSetInputGates;/**< _____________*/
 	deque<a2y_gate_pos_t> m_vPreSetA2YPositions;/**< _____________*/
 	e_role* m_vOutputDestionations; /** <  _____________*/

--- a/src/abycore/sharing/yaosharing.cpp
+++ b/src/abycore/sharing/yaosharing.cpp
@@ -18,6 +18,9 @@
 
 #include "yaosharing.h"
 
+using std::cout;
+using std::endl;
+
 void YaoSharing::Init() {
 	/* init the class for correctly sized Yao key operations*/
 	InitYaoKey(&m_pKeyOps, m_cCrypto->get_seclvl().symbits);

--- a/src/abycore/sharing/yaosharing.h
+++ b/src/abycore/sharing/yaosharing.h
@@ -76,8 +76,8 @@ public:
 
 	virtual void InstantiateGate(GATE* gate) = 0;
 
-	virtual void GetDataToSend(vector<BYTE*>& sendbuf, vector<uint64_t>& bytesize) = 0;
-	virtual void GetBuffersToReceive(vector<BYTE*>& rcvbuf, vector<uint64_t>& rcvbytes) = 0;
+	virtual void GetDataToSend(std::vector<BYTE*>& sendbuf, std::vector<uint64_t>& bytesize) = 0;
+	virtual void GetBuffersToReceive(std::vector<BYTE*>& rcvbuf, std::vector<uint64_t>& rcvbytes) = 0;
 
 	virtual uint32_t AssignInput(CBitVector& input) = 0;
 	virtual uint32_t GetOutput(CBitVector& out) = 0;
@@ -112,9 +112,9 @@ protected:
 	uint32_t m_nXORGates; /**< XOR Gates_____________*/
 
 	XORMasking *fMaskFct; /**< Mask ____________*/
-	vector<GATE*> m_vANDGates; /**< Vector of AND Gates. */
+	std::vector<GATE*> m_vANDGates; /**< Vector of AND Gates. */
 
-	vector<GATE*> m_vOutputShareGates; /**< Vector of output share gates. */
+	std::vector<GATE*> m_vOutputShareGates; /**< Vector of output share gates. */
 
 	uint32_t m_nInputShareSndSize; /**< Input share send size. */
 	uint32_t m_nOutputShareSndSize; /**< Output share send size. */


### PR DESCRIPTION
Dependencies (i.e. OTExtension, ENCRYPTOutils and MIRACL) are still
importing namespace std in header files.