### PR TITLE
Clean abyparty.h and other headers

### DIFF
--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "abyparty.h"
+#include "abysetup.h"
 #include "../circuit/abycircuit.h"
 #include "../sharing/arithsharing.h"
 #include "../sharing/boolsharing.h"

--- a/src/abycore/aby/abysetup.h
+++ b/src/abycore/aby/abysetup.h
@@ -38,10 +38,10 @@
 #include "../ENCRYPTO_utils/sndthread.h"
 #include "../ENCRYPTO_utils/rcvthread.h"
 
-typedef struct {
+struct comm_ctx {
 	SndThread *snd_std, *snd_inv;
 	RcvThread *rcv_std, *rcv_inv;
-} comm_ctx;
+};
 
 
 //#define DEBUGSETUP

--- a/src/abycore/circuit/arithmeticcircuits.h
+++ b/src/abycore/circuit/arithmeticcircuits.h
@@ -22,6 +22,7 @@
 #include "../ENCRYPTO_utils/typedefs.h"
 #include "abycircuit.h"
 #include "circuit.h"
+#include "share.h"
 
 /** Arithmetic Circuit class.*/
 class ArithmeticCircuit: public Circuit {

--- a/src/abycore/circuit/booleancircuits.h
+++ b/src/abycore/circuit/booleancircuits.h
@@ -18,15 +18,16 @@
 #ifndef __BOOLEANCIRCUITS_H_
 #define __BOOLEANCIRCUITS_H_
 
-#include "../ENCRYPTO_utils/typedefs.h"
+#include "share.h"
+#include "../ABY_utils/convtypes.h"
 #include "../ENCRYPTO_utils/cbitvector.h"
+#include "../ENCRYPTO_utils/parse_options.h"
+#include "../ENCRYPTO_utils/typedefs.h"
 #include "abycircuit.h"
 #include <assert.h>
 #include "circuit.h"
 #include <map>
 #include <algorithm>
-#include "../ABY_utils/convtypes.h"
-#include "../ENCRYPTO_utils/parse_options.h"
 
 /** BooleanCircuit class. */
 class BooleanCircuit: public Circuit {

--- a/src/abycore/circuit/circuit.cpp
+++ b/src/abycore/circuit/circuit.cpp
@@ -17,6 +17,7 @@
  \brief		Circuit class implementation.
 */
 #include "circuit.h"
+#include "share.h"
 #include <cstring>
 
 

--- a/src/abycore/circuit/circuit.h
+++ b/src/abycore/circuit/circuit.h
@@ -531,6 +531,4 @@ protected:
 share* create_new_share(uint32_t size, Circuit* circ);
 share* create_new_share(std::vector<uint32_t> vals, Circuit* circ);
 
-#include "share.h"
-
 #endif /* CIRCUIT_H_ */

--- a/src/abycore/circuit/share.cpp
+++ b/src/abycore/circuit/share.cpp
@@ -19,6 +19,7 @@
 
 
 #include "share.h"
+#include "circuit.h"
 #include <cstring>
 
 
@@ -58,6 +59,27 @@ void share::set_wire_id(uint32_t pos_id, uint32_t wireid) {
 	m_ngateids[pos_id] = wireid;
 }
 
+void share::set_wire_ids(std::vector<uint32_t> wires) {
+	m_ngateids = wires;
+}
+
+uint32_t share::get_bitlength() {
+	return m_ngateids.size();
+}
+
+void share::set_bitlength(uint32_t sharelen) {
+	m_ngateids.resize(sharelen);
+}
+
+uint32_t share::get_max_bitlength() {
+	return m_nmaxbitlen;
+}
+
+void share::set_max_bitlength(uint32_t max_bitlength) {
+	assert(max_bitlength >= m_ngateids.size());
+	m_nmaxbitlen = max_bitlength;
+}
+
 /*
  * Returns nvals of this share
  * Asserts that all nvals of all wires are the same, so only use this method if
@@ -74,6 +96,18 @@ uint32_t share::get_nvals() {
 		}
 	}
   return nvals;
+}
+
+uint32_t share::get_nvals_on_wire(uint32_t wireid) {
+	return m_ccirc->GetNumVals(m_ngateids[wireid]);
+}
+
+e_circuit share::get_circuit_type() {
+	return m_ccirc->GetCircuitType();
+}
+
+e_sharing share::get_share_type() {
+	return m_ccirc->GetContext();
 }
 
 /* =========================== Methods for the Boolean share class =========================== */

--- a/src/abycore/circuit/share.h
+++ b/src/abycore/circuit/share.h
@@ -20,6 +20,11 @@
 #define SHARE_H_
 
 #include "circuit.h"
+#include "../ABY_utils/ABYconstants.h"
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
 
 /** Share Class */
 class share {
@@ -50,41 +55,24 @@ public:
 
 	void set_wire_id(uint32_t posid, uint32_t wireid);
 
-	void set_wire_ids(std::vector<uint32_t> wires) {
-		m_ngateids = wires;
-	}
-	;
-	uint32_t get_bitlength() {
-		return m_ngateids.size();
-	}
-	;
-	void set_bitlength(uint32_t sharelen) {
-		m_ngateids.resize(sharelen);
-	}
-	;
-	uint32_t get_max_bitlength() {
-		return m_nmaxbitlen;
-	}
-	;
-	void set_max_bitlength(uint32_t max_bitlength) {
-		assert(max_bitlength >= m_ngateids.size());
-		m_nmaxbitlen = max_bitlength;
-	}
-	;
-	uint32_t get_nvals_on_wire(uint32_t wireid) {
-		return m_ccirc->GetNumVals(m_ngateids[wireid]);
-	};
+	void set_wire_ids(std::vector<uint32_t> wires);
+
+	uint32_t get_bitlength();
+
+	void set_bitlength(uint32_t sharelen);
+
+	uint32_t get_max_bitlength();
+
+	void set_max_bitlength(uint32_t max_bitlength);
 
 	uint32_t get_nvals();
 
-	e_circuit get_circuit_type() {
-		return m_ccirc->GetCircuitType();
-	}
-	;
-	e_sharing get_share_type() {
-		return m_ccirc->GetContext();
-	}
-	;
+	uint32_t get_nvals_on_wire(uint32_t wireid);
+
+	e_circuit get_circuit_type();
+
+	e_sharing get_share_type();
+
 
 	template<class T> T get_clear_value() {
 

--- a/src/abycore/sharing/arithsharing.cpp
+++ b/src/abycore/sharing/arithsharing.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include "arithsharing.h"
+#include "../aby/abysetup.h"
 
 template<typename T>
 void ArithSharing<T>::Init() {

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -16,6 +16,7 @@
  \brief		Bool sharing class implementation.
  */
 #include "boolsharing.h"
+#include "../aby/abysetup.h"
 
 
 void BoolSharing::Init() {

--- a/src/abycore/sharing/boolsharing.h
+++ b/src/abycore/sharing/boolsharing.h
@@ -27,6 +27,8 @@
 #include "../ENCRYPTO_utils/fileops.h"
 #include "../ENCRYPTO_utils/cbitvector.h"
 
+class XORMasking;
+
 //#define DEBUGBOOL
 //#define BENCHBOOLTIME
 /**

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -16,8 +16,29 @@
  \brief		Sharing class implementation.
  */
 #include "sharing.h"
+#include "../circuit/circuit.h"
+#include "../circuit/abycircuit.h"
+#include "../ENCRYPTO_utils/crypto/crypto.h"
+#include "../ENCRYPTO_utils/fileops.h"
+#include <cassert>
 #include <iostream>
 #include <iomanip>
+
+Sharing::Sharing(e_sharing context, e_role role, uint32_t sharebitlen, ABYCircuit* circuit, crypto* crypt) {
+	m_eContext = context;
+	m_nShareBitLen = sharebitlen;
+	m_pCircuit = circuit;
+	m_pGates = m_pCircuit->Gates();
+	m_eRole = role;
+	m_cCrypto = crypt;
+	m_nSecParamBytes = ceil_divide(m_cCrypto->get_seclvl().symbits, 8);
+	m_ePhaseValue = ePreCompDefault;
+	m_nFilePos = -1;
+	m_nTypeBitLen = sharebitlen;
+}
+
+Sharing::~Sharing() {
+}
 
 void Sharing::EvaluateCallbackGate(uint32_t gateid) {
 	GATE* gate = m_pGates + gateid;

--- a/src/abycore/sharing/sharing.h
+++ b/src/abycore/sharing/sharing.h
@@ -21,16 +21,18 @@
 #ifndef __SHARING_H__
 #define __SHARING_H__
 
-//#include "../circuit/circuit.h"
-#include "../circuit/abycircuit.h"
-#include "../circuit/circuit.h"
 #include "../ENCRYPTO_utils/cbitvector.h"
-#include "../aby/abysetup.h"
-#include "../ENCRYPTO_utils/constants.h"
-#include "../ENCRYPTO_utils/crypto/crypto.h"
-#include "../ENCRYPTO_utils/fileops.h"
-#include <assert.h>
+#include "../ABY_utils/ABYconstants.h"
+#include <cstdint>
+#include <vector>
 //#define DEBUGSHARING
+
+class ABYCircuit;
+class ABYSetup;
+class Circuit;
+class crypto;
+struct GATE;
+struct UGATE;
 
 
 /**
@@ -46,25 +48,12 @@ public:
 
 	 \brief 		Initialises the members of the class.
 	 */
-	Sharing(e_sharing context, e_role role, uint32_t sharebitlen, ABYCircuit* circuit, crypto* crypt) {
-		m_eContext = context;
-		m_nShareBitLen = sharebitlen;
-		m_pCircuit = circuit;
-		m_pGates = m_pCircuit->Gates();
-		m_eRole = role;
-		m_cCrypto = crypt;
-		m_nSecParamBytes = ceil_divide(m_cCrypto->get_seclvl().symbits, 8);
-		m_ePhaseValue = ePreCompDefault;
-		m_nFilePos = -1;
-		m_nTypeBitLen = sharebitlen;
-	}
-	;
+	Sharing(e_sharing context, e_role role, uint32_t sharebitlen, ABYCircuit* circuit, crypto* crypt);
+
 	/**
 	 Destructor of class.
 	 */
-	virtual ~Sharing() {
-	}
-	;
+	virtual ~Sharing();
 
 	/**	Reset method */
 	virtual void Reset() = 0;

--- a/src/abycore/sharing/splut.cpp
+++ b/src/abycore/sharing/splut.cpp
@@ -22,6 +22,19 @@
 #include <deque>
 #include <iostream>
 #include <vector>
+#include "../aby/abysetup.h"
+#include "../circuit/booleancircuits.h"
+
+
+SetupLUT::SetupLUT(e_sharing context, e_role role, uint32_t sharebitlen, ABYCircuit* circuit, crypto* crypt)
+	: Sharing(context, role, sharebitlen, circuit, crypt) {
+	Init();
+}
+
+SetupLUT::~SetupLUT() {
+	Reset();
+	delete m_cBoolCircuit;
+}
 
 
 void SetupLUT::Init() {
@@ -1596,6 +1609,10 @@ void SetupLUT::EvaluateSIMDGate(uint32_t gateid) {
 #endif
 }
 
+Circuit* SetupLUT::GetCircuitBuildRoutine() {
+	return m_cBoolCircuit;
+}
+
 uint32_t SetupLUT::AssignInput(CBitVector& inputvals) {
 	std::deque<uint32_t> myingates = m_cBoolCircuit->GetInputGatesForParty(m_eRole);
 	inputvals.Create((uint64_t) m_cBoolCircuit->GetNumInputBitsForParty(m_eRole), m_cCrypto);
@@ -1637,6 +1654,10 @@ uint32_t SetupLUT::GetOutput(CBitVector& out) {
 		}
 	}
 	return outbits;
+}
+
+uint32_t SetupLUT::GetMaxCommunicationRounds() {
+	return m_cBoolCircuit->GetMaxDepth()+1;
 }
 
 void SetupLUT::PrintPerformanceStatistics() {

--- a/src/abycore/sharing/splut.h
+++ b/src/abycore/sharing/splut.h
@@ -22,9 +22,12 @@
 #include "sharing.h"
 #include <algorithm>
 #include <vector>
+#include "../circuit/abycircuit.h"
 #include "../ENCRYPTO_utils/cbitvector.h"
 #include "../ENCRYPTO_utils/timer.h"
-#include "../circuit/booleancircuits.h"
+
+class BooleanCircuit;
+class XORMasking;
 
 constexpr uint64_t aes_sbox_multi_seq_perm_out_ttable[16][32] =
  { { 0xc56f6bf27b777c63L , 0x76abd7fe2b670130L , 0x6fc5f26b777b637cL , 0xab76fed7672b3001L , 0x6bf2c56f7c637b77L , 0xd7fe76ab01302b67L , 0xf26b6fc5637c777bL , 0xfed7ab763001672bL , 0x7b777c63c56f6bf2L , 0x2b67013076abd7feL , 0x777b637c6fc5f26bL , 0x672b3001ab76fed7L , 0x7c637b776bf2c56fL , 0x1302b67d7fe76abL , 0x637c777bf26b6fc5L , 0x3001672bfed7ab76L , 0x76abd7fe2b670130L , 0xc56f6bf27b777c63L , 0xab76fed7672b3001L , 0x6fc5f26b777b637cL , 0xd7fe76ab01302b67L , 0x6bf2c56f7c637b77L , 0xfed7ab763001672bL , 0xf26b6fc5637c777bL , 0x2b67013076abd7feL , 0x7b777c63c56f6bf2L , 0x672b3001ab76fed7L , 0x777b637c6fc5f26bL , 0x1302b67d7fe76abL , 0x7c637b776bf2c56fL , 0x3001672bfed7ab76L , 0x637c777bf26b6fc5L},
@@ -57,18 +60,10 @@ class SetupLUT: public Sharing {
 
 public:
 	/** Constructor of the class.*/
-	SetupLUT(e_sharing context, e_role role, uint32_t sharebitlen, ABYCircuit* circuit, crypto* crypt) :\
+	SetupLUT(e_sharing context, e_role role, uint32_t sharebitlen, ABYCircuit* circuit, crypto* crypt);
 
-			Sharing(context, role, sharebitlen, circuit, crypt) {
-		Init();
-	}
-	;
 	/** Destructor of the class.*/
-	virtual ~SetupLUT() {
-		Reset();
-		delete m_cBoolCircuit;
-	}
-	;
+	virtual ~SetupLUT();
 
 	//SUPER CLASS MEMBER FUNCTION
 	void PrepareSetupPhase(ABYSetup* setup);
@@ -92,18 +87,13 @@ public:
 
 	void EvaluateSIMDGate(uint32_t gateid);
 
-	Circuit* GetCircuitBuildRoutine() {
-		return m_cBoolCircuit;
-	}
-	;
+	Circuit* GetCircuitBuildRoutine();
 
 	uint32_t AssignInput(CBitVector& input);
 	uint32_t GetOutput(CBitVector& out);
 
-	uint32_t GetMaxCommunicationRounds() {
-		return m_cBoolCircuit->GetMaxDepth()+1;
-	}
-	;
+	uint32_t GetMaxCommunicationRounds();
+
 	uint32_t GetNumNonLinearOperations() {
 		return m_nTotalTTs;
 	}

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -16,6 +16,7 @@
  \brief		Yao Client Sharing class implementation.
  */
 #include "yaoclientsharing.h"
+#include "../aby/abysetup.h"
 
 void YaoClientSharing::InitClient() {
 

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "yaoserversharing.h"
+#include "../aby/abysetup.h"
 
 void YaoServerSharing::InitServer() {
 

--- a/src/abycore/sharing/yaosharing.h
+++ b/src/abycore/sharing/yaosharing.h
@@ -23,8 +23,11 @@
 #include "../ABY_utils/yaokey.h"
 #include "../circuit/booleancircuits.h"
 #include "../ENCRYPTO_utils/constants.h"
+#include "../ENCRYPTO_utils/crypto/crypto.h"
 
 #define FIXED_KEY_GARBLING
+
+class XORMasking;
 
 typedef struct {
 	uint32_t gateid;

--- a/src/examples/aes/common/aescircuit.cpp
+++ b/src/examples/aes/common/aescircuit.cpp
@@ -16,6 +16,9 @@
  \brief		Implementation of AESCiruit
  */
 #include "aescircuit.h"
+#include "../../../abycore/circuit/booleancircuits.h"
+#include "../../../abycore/sharing/sharing.h"
+#include "../../../abycore/ENCRYPTO_utils/cbitvector.h"
 
 int32_t test_aes_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads,
 		e_mt_gen_alg mt_alg, e_sharing sharing, bool verbose, bool use_vec_ands) {

--- a/src/examples/aes/common/aescircuit.h
+++ b/src/examples/aes/common/aescircuit.h
@@ -24,6 +24,8 @@
 #include "../../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 #include <cassert>
 
+class BooleanCircuit;
+
 #define AES_ROUNDS 10
 #define AES_STATE_SIZE 16
 #define AES_STATE_SIZE_BITS 128

--- a/src/examples/bench_operations/bench_operations.cpp
+++ b/src/examples/bench_operations/bench_operations.cpp
@@ -17,6 +17,8 @@
  */
 
 //Utility libs
+#include "../../abycore/sharing/sharing.h"
+#include "../../abycore/circuit/booleancircuits.h"
 #include "../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 #include "../../abycore/ENCRYPTO_utils/parse_options.h"
 #include "../aes/common/aescircuit.h"

--- a/src/examples/euclidean_distance/common/euclidean_dist.cpp
+++ b/src/examples/euclidean_distance/common/euclidean_dist.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "euclidean_dist.h"
+#include "../../../abycore/sharing/sharing.h"
 
 int32_t test_euclid_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,

--- a/src/examples/float/abyfloat.cpp
+++ b/src/examples/float/abyfloat.cpp
@@ -18,6 +18,10 @@
 #include "../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 #include "../../abycore/ENCRYPTO_utils/parse_options.h"
 #include "../../abycore/aby/abyparty.h"
+#include "../../abycore/circuit/share.h"
+#include "../../abycore/circuit/booleancircuits.h"
+#include "../../abycore/sharing/sharing.h"
+#include <cassert>
 #include <iomanip>
 #include <iostream>
 

--- a/src/examples/innerproduct/common/innerproduct.cpp
+++ b/src/examples/innerproduct/common/innerproduct.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "innerproduct.h"
+#include "../../../abycore/sharing/sharing.h"
 
 int32_t test_inner_product_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,

--- a/src/examples/lowmc/common/lowmccircuit.cpp
+++ b/src/examples/lowmc/common/lowmccircuit.cpp
@@ -17,6 +17,7 @@
  */
 #include "lowmccircuit.h"
 #include "../../../abycore/sharing/sharing.h"
+#include "../../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 
 //sboxes (m), key-length (k), statesize (n), data (d), rounds (r)
 int32_t test_lowmc_circuit(e_role role, char* address, uint16_t port, uint32_t nvals, uint32_t nthreads,

--- a/src/examples/lowmc/common/lowmccircuit.cpp
+++ b/src/examples/lowmc/common/lowmccircuit.cpp
@@ -16,6 +16,7 @@
  \brief		Prototypical benchmark implementation of LowMCCiruit. Attention: Does not yield correct result!
  */
 #include "lowmccircuit.h"
+#include "../../../abycore/sharing/sharing.h"
 
 //sboxes (m), key-length (k), statesize (n), data (d), rounds (r)
 int32_t test_lowmc_circuit(e_role role, char* address, uint16_t port, uint32_t nvals, uint32_t nthreads,

--- a/src/examples/lowmc/lowmc.cpp
+++ b/src/examples/lowmc/lowmc.cpp
@@ -18,6 +18,7 @@
 
 #include "common/lowmccircuit.h"
 #include "../../abycore/ENCRYPTO_utils/parse_options.h"
+#include "../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 #include "../../abycore/aby/abyparty.h"
 
 int32_t read_test_options(int32_t* argcp, char*** argvp, e_role* role, uint32_t* nvals, uint32_t* secparam, std::string* address, uint16_t* port, uint32_t* statesize, uint32_t* keysize,

--- a/src/examples/millionaire_prob/common/millionaire_prob.cpp
+++ b/src/examples/millionaire_prob/common/millionaire_prob.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "millionaire_prob.h"
+#include "../../../abycore/circuit/booleancircuits.h"
+#include "../../../abycore/sharing/sharing.h"
 
 int32_t test_millionaire_prob_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,

--- a/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.cpp
+++ b/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.cpp
@@ -18,6 +18,7 @@
 #include "min-euclidean-dist-circuit.h"
 #include "../../../abycore/circuit/booleancircuits.h"
 #include "../../../abycore/sharing/sharing.h"
+#include "../../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 #include <iostream>
 #include <vector>
 

--- a/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.cpp
+++ b/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.cpp
@@ -16,6 +16,8 @@
  \brief		Implementation of Minimum Euclidean Distance Circuit
  */
 #include "min-euclidean-dist-circuit.h"
+#include "../../../abycore/circuit/booleancircuits.h"
+#include "../../../abycore/sharing/sharing.h"
 #include <iostream>
 #include <vector>
 

--- a/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.h
+++ b/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.h
@@ -24,6 +24,8 @@
 #include <cassert>
 #include <vector>
 
+class BooleanCircuit;
+
 uint64_t verify_min_euclidean_dist(uint32_t** serverdb, uint32_t* clientquery, uint32_t dbsize, uint32_t dim);
 int32_t test_min_eucliden_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t dbsize, uint32_t dim,
 		uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing dstsharing, e_sharing minsharing, ePreCompPhase pre_comp_value);

--- a/src/examples/psi_phasing/common/phasing_circuit.cpp
+++ b/src/examples/psi_phasing/common/phasing_circuit.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "phasing_circuit.h"
+#include "../../../abycore/sharing/sharing.h"
 
 #include <math.h>
 #include <cassert>

--- a/src/examples/psi_scs/common/sort_compare_shuffle.cpp
+++ b/src/examples/psi_scs/common/sort_compare_shuffle.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "sort_compare_shuffle.h"
+#include "../../../abycore/sharing/sharing.h"
 
 #include <math.h>
 #include <cassert>

--- a/src/examples/sha1/common/sha1_circuit.cpp
+++ b/src/examples/sha1/common/sha1_circuit.cpp
@@ -16,6 +16,10 @@
  \brief		Implementation of the SHA1 hash function (which should not be used in practice anymore!)
  */
 #include "sha1_circuit.h"
+#include "../../../abycore/circuit/booleancircuits.h"
+#include "../../../abycore/sharing/sharing.h"
+#include "../../../abycore/ENCRYPTO_utils/cbitvector.h"
+#include "../../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 
 int32_t test_sha1_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing) {
 	uint32_t bitlen = 32;

--- a/src/examples/sha1/common/sha1_circuit.h
+++ b/src/examples/sha1/common/sha1_circuit.h
@@ -24,6 +24,8 @@
 #include "../../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 #include <cassert>
 
+class BooleanCircuit;
+
 #define ABY_SHA1_INPUT_BITS 512
 #define ABY_SHA1_INPUT_BYTES ABY_SHA1_INPUT_BITS/8
 

--- a/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.cpp
+++ b/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.cpp
@@ -18,6 +18,8 @@
  *              Implements the functionality from PST’15 (http://ieeexplore.ieee.org/document/7232947/).
  */
 #include "threshold-euclidean-dist.h"
+#include "../../../abycore/circuit/booleancircuits.h"
+#include "../../../abycore/sharing/sharing.h"
 
 int32_t test_min_eucliden_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t pointbitlen,
         uint32_t thresbitlen, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing dstsharing, e_sharing minsharing, uint32_t n,

--- a/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.cpp
+++ b/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.cpp
@@ -20,6 +20,7 @@
 #include "threshold-euclidean-dist.h"
 #include "../../../abycore/circuit/booleancircuits.h"
 #include "../../../abycore/sharing/sharing.h"
+#include "../../../abycore/ENCRYPTO_utils/crypto/crypto.h"
 
 int32_t test_min_eucliden_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t pointbitlen,
         uint32_t thresbitlen, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing dstsharing, e_sharing minsharing, uint32_t n,

--- a/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.h
+++ b/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.h
@@ -27,6 +27,8 @@
 #include "../../../abycore/aby/abyparty.h"
 #include <cassert>
 
+class BooleanCircuit;
+
 //void verify_min_euclidean_dist(uint32_t* x1, uint32_t* x2, uint32_t* y1,
 //        uint32_t* y2, uint32_t * res, uint32_t n, uint32_t t);
 void verify_min_euclidean_dist(uint64_t* x1, uint64_t* x2, uint64_t* y1,


### PR DESCRIPTION
This removes a lot of includes from the header files, especially from `abyparty.h`. It also moves some method implementations to the .cpp files such that we can get rid of more includes and uses forward declarations instead.

* Removed a lot of unnecessary includes from abyparty.h and use forward
  declarations instead.
* Removed unused return value of `ExecCircuit`.
* Removed `ExecSetupPhase` method which was not even implemented.
* Moved member class CPartyWorkerThread to .cpp file.
* Removed unnecessary typedef of struct `comm_ctx`.
* Use unique_ptr for CEvent/CLock members.
* Fix includes/forward declarations in example applications.
* Moved method implementations to .cpp file.
* Removed unnecessary header files.
* Used forward declarations.

@sebastianst Without moving a lot of code around, this should make the usage of `abyparty.h` and `share.h` a bit more pleasant.