### PR TITLE
Use GCC 8 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ before_install:
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get install -qq g++-6
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
+  - sudo apt-get install -qq g++-8
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
 
 addons:
   apt:
     packages:
     - libgmp-dev
-    - libglib2.0-dev
     - libssl-dev
 
 script:


### PR DESCRIPTION
Travis now uses GCC 8 and GLib was not needed.