### PR TITLE
Rename to BinaryOp_v_uint32_t

### DIFF
--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -2134,7 +2134,7 @@ share* BooleanCircuit::PutMaxGate(share** a, uint32_t size) {
 }
 
 std::vector<uint32_t> BooleanCircuit::PutMaxGate(const std::vector<std::vector<uint32_t>>& ws) {
-	BinaryOp_uint32_t op = [this](auto a, auto b) {
+	BinaryOp_v_uint32_t op = [this](auto a, auto b) {
 				uint32_t cmp = (m_eContext == S_YAO) ?
 					PutSizeOptimizedGTGate(a, b) :
 					PutDepthOptimizedGTGate(a, b);

--- a/src/abycore/circuit/circuit.h
+++ b/src/abycore/circuit/circuit.h
@@ -66,7 +66,7 @@ T binary_accumulate(std::vector<T> vals,
  * A binary operation on uint32_t
  * Those are passed to binary_accumulate() as op
  */
-using BinaryOp_uint32_t = std::function<std::vector<uint32_t>
+using BinaryOp_v_uint32_t = std::function<std::vector<uint32_t>
 	(const std::vector<uint32_t>&, const std::vector<uint32_t>&)>;
 
 /** Circuit class */


### PR DESCRIPTION
The alias is actual for a binary operation on `vector`s of `uint32_t`, so rename.