### PR TITLE
use std::filesystem instead of fileops from utils

### DIFF
--- a/src/abycore/CMakeLists.txt
+++ b/src/abycore/CMakeLists.txt
@@ -27,6 +27,13 @@ target_include_directories(aby
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
 )
 
+# This assumes that libstdc++ is used and should not be required for e.g.
+# libc++.  Linking to libstdc++fs is currently required when using the
+# std::filesystem library.
+# cf. https://gitlab.kitware.com/cmake/cmake/issues/17834
+target_link_libraries(aby
+	PRIVATE stdc++fs
+)
 
 target_link_libraries(aby
     PUBLIC OTExtension::otextension

--- a/src/abycore/sharing/boolsharing.h
+++ b/src/abycore/sharing/boolsharing.h
@@ -24,7 +24,6 @@
 #include <map>
 #include <vector>
 #include "../circuit/booleancircuits.h"
-#include <ENCRYPTO_utils/fileops.h>
 #include <ENCRYPTO_utils/cbitvector.h>
 
 class XORMasking;
@@ -276,12 +275,12 @@ private:
 	/**
 	 Method for store MTs to File
 	*/
-	void StoreMTsToFile(char *filename);
+	void StoreMTsToFile(const char *filename);
 
 	/**
 	 Method for read MTs from file
 	*/
-	void ReadMTsFromFile(char *filename);
+	void ReadMTsFromFile(const char *filename);
 	/**
 	Method to check if it is the right nvals or the circuit size.
 	*/

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -19,9 +19,9 @@
 #include "../circuit/circuit.h"
 #include "../circuit/abycircuit.h"
 #include <ENCRYPTO_utils/crypto/crypto.h>
-#include <ENCRYPTO_utils/fileops.h>
 #include <cassert>
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <iomanip>
 
@@ -64,24 +64,26 @@ ePreCompPhase Sharing::GetPreCompPhaseValue() {
 	return m_ePhaseValue;
 }
 void Sharing::PreCompFileDelete() {
-	char filename[21];
 	uint64_t truncation_size;
+	std::filesystem::path filename;
 	if(m_eRole == SERVER) {
-		strcpy(filename, "pre_comp_server.dump");
-	}
-	else {
-		strcpy(filename, "pre_comp_client.dump");
+		filename = "pre_comp_server.dump";
+	} else {
+		filename = "pre_comp_client.dump";
 	}
 
-	if((FileExists(filename))&&(GetPreCompPhaseValue() == ePreCompRead)) {
+	if((std::filesystem::exists(filename))&&(GetPreCompPhaseValue() == ePreCompRead)) {
 
-		if(m_nFilePos >= FileSize(filename)) {
-			remove(filename);
+		if(m_nFilePos >= std::filesystem::file_size(filename)) {
+			std::filesystem::remove(filename);
 		}
 		else {
-			truncation_size = FileSize(filename) - m_nFilePos;
-			if(truncate(filename, truncation_size))
-                        std::cout << "Error occured in truncate" << std::endl;
+			truncation_size = std::filesystem::file_size(filename) - m_nFilePos;
+			std::error_code ec;
+			std::filesystem::resize_file(filename, truncation_size, ec);
+			if(ec) {
+				std::cout << "Error occured in truncate:" << ec.message() << std::endl;
+			}
 		}
 	}
 }


### PR DESCRIPTION
The file operations from the ENCRYPTO_utils fileops.h are replaced by
their counterparts from the C++17's std::filesystem library.

Note: The surrounding code still contains bugs. For example
m_nFilePos is declared unsigned and assigned a value of -1.