### PR TITLE
Move online initialization from constructor into separate method.

### DIFF
--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -122,7 +122,10 @@ ABYParty::ABYParty(e_role pid, const char* addr, uint16_t port, seclvl seclvl,
 		exit(0);
 	}
 	StopWatch("Time for circuit generation: ", P_CIRCUIT);
+}
 
+
+void ABYParty::InitOnline() {
 #ifndef BATCH
 	std::cout << "Establishing network connection" << std::endl;
 #endif
@@ -141,6 +144,8 @@ ABYParty::ABYParty(e_role pid, const char* addr, uint16_t port, seclvl seclvl,
 	StartRecording("Starting NP OT", P_BASE_OT, m_vSockets);
 	m_pSetup->PrepareSetupPhase(m_tComm);
 	StopRecording("Time for NP OT: ", P_BASE_OT, m_vSockets);
+
+	is_online = true;
 }
 
 ABYParty::~ABYParty() {
@@ -224,6 +229,10 @@ void ABYParty::ExecCircuit() {
 #ifndef BATCH
 	std::cout << "Finishing circuit generation" << std::endl;
 #endif
+
+	if (!is_online) {
+		InitOnline();
+	}
 
 	StartRecording("Starting execution", P_TOTAL, m_vSockets);
 

--- a/src/abycore/aby/abyparty.h
+++ b/src/abycore/aby/abyparty.h
@@ -44,6 +44,13 @@ public:
 			uint32_t nthreads =	2, e_mt_gen_alg mg_algo = MT_OT, uint32_t maxgates = 4000000);
 	~ABYParty();
 
+	/**
+	 * Online part of initialization. Needs to be called after ABYParty has been
+	 * construced. If not called, it is implicitly called at the first call to
+	 * ExecCircuit() for backwards compatibility.
+	 */
+	void InitOnline();
+
 	std::vector<Sharing*>& GetSharings();
 	void ExecCircuit();
 
@@ -79,6 +86,8 @@ private:
 	BOOL ThreadReceiveValues();
 
 	void PrintPerformanceStatistics();
+
+	bool is_online = false;
 
 	e_mt_gen_alg m_eMTGenAlg;
 	ABYSetup* m_pSetup;


### PR DESCRIPTION
This is more convenient in situations where the `ABYParty` object is instantiated before the network connection shall be established. (Like necessary in our current project)
Now `ABYParty::InitOnline()` has to be called after the object is constructed.
However, for backwards compatibility, this separated online initialization is implicitly called from `ExecCircuit()` the first time it is run. So existing code still works without changes.