### PR TITLE
Fix B2A conversion

### DIFF
--- a/src/abycore/circuit/arithmeticcircuits.cpp
+++ b/src/abycore/circuit/arithmeticcircuits.cpp
@@ -250,7 +250,7 @@ uint32_t ArithmeticCircuit::PutINVGate(uint32_t parentid) {
 uint32_t ArithmeticCircuit::PutCONVGate(std::vector<uint32_t> parentids) {
 	uint32_t gateid = m_cCircuit->PutCONVGate(parentids, 2, S_ARITH, m_nShareBitLen);
 	UpdateInteractiveQueue(gateid);
-	m_nCONVGates += m_pGates[gateid].nvals;
+	m_nCONVGates += m_pGates[gateid].nvals * parentids.size();
 	return gateid;
 }
 

--- a/src/abycore/sharing/arithsharing.h
+++ b/src/abycore/sharing/arithsharing.h
@@ -33,17 +33,18 @@ class ArithSharing: public Sharing {
 public:
 	/** Constructor of the class.*/
 	ArithSharing(e_sharing context, e_role role, uint32_t sharebitlen, ABYCircuit* circuit, crypto* crypt, e_mt_gen_alg mt_alg) :
-			Sharing(context, role, sharebitlen, circuit, crypt) {
-		m_eMTGenAlg = mt_alg;
+			Sharing(context, role, sharebitlen, circuit, crypt),
+			m_eMTGenAlg{mt_alg},
+			m_vConversionMasks(2)
+	{
 		Init();
-	}
-	;
+	};
+
 	/** Destructor of the class.*/
 	~ArithSharing() {
 		Reset();
 		delete m_cArithCircuit;
-	}
-	;
+	};
 
 	//MEMBER FUNCTIONS OF THE SUPER CLASS
 	void Reset();

--- a/src/abycore/sharing/arithsharing.h
+++ b/src/abycore/sharing/arithsharing.h
@@ -123,7 +123,12 @@ private:
         std::vector<GATE*> m_vMULGates;
         std::vector<GATE*> m_vInputShareGates;
         std::vector<GATE*> m_vOutputShareGates;
+        /* We collect conversion shares for round 1 in this vector (SERVER uses
+         * them in AssignServerConversionShares) */
         std::vector<GATE*> m_vCONVGates;
+        /* We collect conversion shares for round 2 in this vector (CLIENT uses
+         * them in AssignClientConversionShares) */
+        std::vector<GATE*> m_vCONVGates2;
 
 	uint32_t m_nInputShareSndCtr;
 	uint32_t m_nOutputShareSndCtr;
@@ -155,9 +160,13 @@ private:
 
 	CBitVector m_vConversionRandomness;
 
-	uint32_t m_nConvShareIdx; //the global
-	uint32_t m_nConvShareSndCtr; //counts for each round
-	uint32_t m_nConvShareRcvCtr;
+	// Global index into conversion buffers for randomness and OTs
+	uint32_t m_nConvShareIdx;
+	// 2nd layer (client side) needs its own counter to not interfere with prevous layer
+	uint32_t m_nConvShareIdx2;
+	uint32_t m_nConvShareSndCtr; // Network send counter per round
+	uint32_t m_nConvShareRcvCtr; // Network receive counter per round
+
 	/**
 	 Share Values
 	 \param 	gate 	Object of class Gate


### PR DESCRIPTION
B2A Conversion takes two rounds. If two conversions happen on
consecutive layers, some information that the client side needs in the
2nd round of the first conversion are overwritten by the first round of
the second conversion.
Now this information is saved to `m_vCONVGates2` and `m_nConvShareIdx2` at
a carefully selected position.
I also added some commentary so that the next brave soul who, like me, hasn't a telepathic connection to the original author has a better chance of understanding what is going on with the B2A conversion.
No fun.