### PR TITLE
ABYParty: Use std::string instead of char*

### DIFF
--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -59,7 +59,7 @@ private:
 	std::mutex m_eJob_mutex_;
 };
 
-ABYParty::ABYParty(e_role pid, const char* addr, uint16_t port, seclvl seclvl,
+ABYParty::ABYParty(e_role pid, const std::string& addr, uint16_t port, seclvl seclvl,
 	uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mg_algo,
 	uint32_t maxgates)
 	: m_eMTGenAlg(mg_algo), m_eRole(pid), m_nPort(port), m_sSecLvl(seclvl),

--- a/src/abycore/aby/abyparty.h
+++ b/src/abycore/aby/abyparty.h
@@ -40,7 +40,7 @@ class CLock;
 
 class ABYParty {
 public:
-	ABYParty(e_role pid, const char* addr = (char*) "127.0.0.1", uint16_t port = 7766, seclvl seclvl = LT, uint32_t bitlen = 32,
+	ABYParty(e_role pid, const std::string& addr = "127.0.0.1", uint16_t port = 7766, seclvl seclvl = LT, uint32_t bitlen = 32,
 			uint32_t nthreads =	2, e_mt_gen_alg mg_algo = MT_OT, uint32_t maxgates = 4000000);
 	~ABYParty();
 
@@ -93,7 +93,7 @@ private:
 
 	uint32_t m_nHelperThreads;
 
-	const char* m_cAddress;
+	const std::string m_cAddress;
 
 	uint32_t m_nDepth;
 

--- a/src/examples/aes/aes_test.cpp
+++ b/src/examples/aes/aes_test.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
 
 	seclvl seclvl = get_sec_lvl(secparam);
 
-	test_aes_circuit(role, (char*) address.c_str(), port, seclvl, nvals, nthreads, mt_alg, sharing, verbose, use_vec_ands);
+	test_aes_circuit(role, address, port, seclvl, nvals, nthreads, mt_alg, sharing, verbose, use_vec_ands);
 
 	return 0;
 }

--- a/src/examples/aes/common/aescircuit.cpp
+++ b/src/examples/aes/common/aescircuit.cpp
@@ -20,7 +20,7 @@
 #include "../../../abycore/sharing/sharing.h"
 #include <ENCRYPTO_utils/cbitvector.h>
 
-int32_t test_aes_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads,
+int32_t test_aes_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads,
 		e_mt_gen_alg mt_alg, e_sharing sharing, bool verbose, bool use_vec_ands) {
 	uint32_t bitlen = 32;
 	uint32_t aes_key_bits;

--- a/src/examples/aes/common/aescircuit.h
+++ b/src/examples/aes/common/aescircuit.h
@@ -135,7 +135,7 @@ static uint32_t* pos_even;
 static uint32_t* pos_odd;
 
 void verify_AES_encryption(uint8_t* input, uint8_t* key, uint32_t nvals, uint8_t* out, crypto* crypt);
-int32_t test_aes_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, bool verbose = false, bool use_vec_ands=false);
+int32_t test_aes_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, bool verbose = false, bool use_vec_ands=false);
 share* BuildAESCircuit(share* val, share* key, BooleanCircuit* circ, bool use_vec_ands=false);
 std::vector<uint32_t> AddAESRoundKey(std::vector<uint32_t>& val, std::vector<uint32_t> key, uint32_t keyaddr, BooleanCircuit* circ);
 std::vector<uint32_t> Mul2(std::vector<uint32_t>& element, BooleanCircuit* circ);

--- a/src/examples/bench_operations/bench_operations.cpp
+++ b/src/examples/bench_operations/bench_operations.cpp
@@ -478,7 +478,7 @@ int32_t bench_operations(aby_ops_t* bench_ops, uint32_t nops, ABYParty* party, u
 }
 
 
-bool run_bench(e_role role, char* address, uint16_t port, seclvl seclvl, int32_t operation, int32_t bitlen, uint32_t nvals,
+bool run_bench(e_role role, const std::string& address, uint16_t port, seclvl seclvl, int32_t operation, int32_t bitlen, uint32_t nvals,
 		uint32_t nruns, e_mt_gen_alg mt_alg, uint32_t nthreads, bool numbers_only, bool no_verify, bool detailed) {
 
 	uint32_t nops, nbitlens;
@@ -544,7 +544,7 @@ int main(int argc, char** argv) {
 
 	seclvl seclvl = get_sec_lvl(secparam);
 
-	run_bench(role, (char*) address.c_str(), port, seclvl, operation, bitlen, nvals, nruns, mt_alg, nthreads, numbers_only, no_verify, detailed);
+	run_bench(role, address, port, seclvl, operation, bitlen, nvals, nruns, mt_alg, nthreads, numbers_only, no_verify, detailed);
 
 	return 0;
 }

--- a/src/examples/euclidean_distance/common/euclidean_dist.cpp
+++ b/src/examples/euclidean_distance/common/euclidean_dist.cpp
@@ -19,7 +19,7 @@
 #include "euclidean_dist.h"
 #include "../../../abycore/sharing/sharing.h"
 
-int32_t test_euclid_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_euclid_dist_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		e_sharing sharing) {
 

--- a/src/examples/euclidean_distance/common/euclidean_dist.h
+++ b/src/examples/euclidean_distance/common/euclidean_dist.h
@@ -38,7 +38,7 @@
  \brief		This function is used for running a testing environment for finding the
  Euclidean Distance.
  */
-int32_t test_euclid_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_euclid_dist_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		e_sharing sharing);
 

--- a/src/examples/euclidean_distance/euclidean_distance_test.cpp
+++ b/src/examples/euclidean_distance/euclidean_distance_test.cpp
@@ -67,10 +67,10 @@ int main(int argc, char** argv) {
 
 	seclvl seclvl = get_sec_lvl(secparam);
 
-	test_euclid_dist_circuit(role, (char*) address.c_str(), port, seclvl, 1, 32,
+	test_euclid_dist_circuit(role, address, port, seclvl, 1, 32,
 			nthreads, mt_alg, S_YAO);
 
-	test_euclid_dist_circuit(role, (char*) address.c_str(), port, seclvl, 1, 32,
+	test_euclid_dist_circuit(role, address, port, seclvl, 1, 32,
 			nthreads, mt_alg, S_BOOL);
 
 	return 0;

--- a/src/examples/float/abyfloat.cpp
+++ b/src/examples/float/abyfloat.cpp
@@ -64,7 +64,7 @@ void read_test_options(int32_t* argcp, char*** argvp, e_role* role,
 	*test_bit = int_testbit;
 }
 
-void test_verilog_add64_SIMD(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads,
+void test_verilog_add64_SIMD(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads,
 	e_mt_gen_alg mt_alg, e_sharing sharing, double afp, double bfp) {
 
 	// we operate on doubles, so set bitlen to 64 bits
@@ -148,7 +148,7 @@ int main(int argc, char** argv) {
 	seclvl seclvl = get_sec_lvl(secparam);
 
 
-	test_verilog_add64_SIMD(role, (char*) address.c_str(), port, seclvl, nvals, nthreads, mt_alg, S_BOOL, fpa, fpb);
+	test_verilog_add64_SIMD(role, address, port, seclvl, nvals, nthreads, mt_alg, S_BOOL, fpa, fpb);
 
 	return 0;
 }

--- a/src/examples/innerproduct/common/innerproduct.cpp
+++ b/src/examples/innerproduct/common/innerproduct.cpp
@@ -19,7 +19,7 @@
 #include "innerproduct.h"
 #include "../../../abycore/sharing/sharing.h"
 
-int32_t test_inner_product_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_inner_product_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		e_sharing sharing, uint32_t num) {
 

--- a/src/examples/innerproduct/common/innerproduct.h
+++ b/src/examples/innerproduct/common/innerproduct.h
@@ -40,7 +40,7 @@
  \brief		This function is used for running a testing environment for solving the
  Inner Product.
  */
-int32_t test_inner_product_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_inner_product_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		e_sharing sharing, uint32_t num);
 

--- a/src/examples/innerproduct/innerproduct_test.cpp
+++ b/src/examples/innerproduct/innerproduct_test.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
 	seclvl seclvl = get_sec_lvl(secparam);
 
 	// call inner product routine. set size with cmd-parameter -n <size>
-	test_inner_product_circuit(role, (char*) address.c_str(), port, seclvl, 1, 16, nthreads, mt_alg, S_ARITH, nvals);
+	test_inner_product_circuit(role, address, port, seclvl, 1, 16, nthreads, mt_alg, S_ARITH, nvals);
 
 	return 0;
 }

--- a/src/examples/lowmc/common/lowmccircuit.cpp
+++ b/src/examples/lowmc/common/lowmccircuit.cpp
@@ -20,7 +20,7 @@
 #include <ENCRYPTO_utils/crypto/crypto.h>
 
 //sboxes (m), key-length (k), statesize (n), data (d), rounds (r)
-int32_t test_lowmc_circuit(e_role role, char* address, uint16_t port, uint32_t nvals, uint32_t nthreads,
+int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads,
 		e_mt_gen_alg mt_alg, e_sharing sharing, uint32_t statesize, uint32_t keysize,
 		uint32_t sboxes, uint32_t rounds, uint32_t maxnumgates, crypto* crypt) {
 
@@ -28,7 +28,7 @@ int32_t test_lowmc_circuit(e_role role, char* address, uint16_t port, uint32_t n
 	return test_lowmc_circuit(role, address, port, nvals, nthreads, mt_alg, sharing, &param, maxnumgates, crypt);
 }
 
-int32_t test_lowmc_circuit(e_role role, char* address, uint16_t port, uint32_t nvals, uint32_t nthreads,
+int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads,
 		e_mt_gen_alg mt_alg, e_sharing sharing, LowMCParams* param, uint32_t maxgates, crypto* crypt) {
 
 	uint32_t bitlen = 32, ctr = 0, exp_key_bitlen = param->blocksize * (param->nrounds+1), zero_gate;

--- a/src/examples/lowmc/common/lowmccircuit.h
+++ b/src/examples/lowmc/common/lowmccircuit.h
@@ -56,9 +56,9 @@ static CBitVector m_vRandomBits;
 static code* m_tGrayCode;
 static uint32_t m_nZeroGate;
 
-int32_t test_lowmc_circuit(e_role role, char* address, uint16_t port, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, uint32_t statesize, uint32_t keysize,
+int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, uint32_t statesize, uint32_t keysize,
 		uint32_t sboxes, uint32_t rounds, uint32_t maxnumgates, crypto* crypt);
-int32_t test_lowmc_circuit(e_role role, char* address, uint16_t port, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, LowMCParams* param, uint32_t maxgates,
+int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, LowMCParams* param, uint32_t maxgates,
 		crypto* crypt);
 share* BuildLowMCCircuit(share* val, share* key, BooleanCircuit* circ, LowMCParams* param, uint32_t zerogate, crypto* crypt);
 void LowMCAddRoundKey(std::vector<uint32_t>& val, std::vector<uint32_t> key, uint32_t locmcstatesize, uint32_t round, BooleanCircuit* circ);

--- a/src/examples/lowmc/lowmc.cpp
+++ b/src/examples/lowmc/lowmc.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 
 	crypto* crypt = new crypto(secparam, (uint8_t*) const_seed);
 
-	test_lowmc_circuit(role, (char*) address.c_str(), port, nvals, nthreads, mt_alg, S_BOOL, statesize, keysize, sboxes, rounds, maxnumgates, crypt);
+	test_lowmc_circuit(role, address, port, nvals, nthreads, mt_alg, S_BOOL, statesize, keysize, sboxes, rounds, maxnumgates, crypt);
 
 	return 0;
 }

--- a/src/examples/millionaire_prob/common/millionaire_prob.cpp
+++ b/src/examples/millionaire_prob/common/millionaire_prob.cpp
@@ -20,7 +20,7 @@
 #include "../../../abycore/circuit/booleancircuits.h"
 #include "../../../abycore/sharing/sharing.h"
 
-int32_t test_millionaire_prob_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_millionaire_prob_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		e_sharing sharing) {
 

--- a/src/examples/millionaire_prob/common/millionaire_prob.h
+++ b/src/examples/millionaire_prob/common/millionaire_prob.h
@@ -41,7 +41,7 @@
  \brief		This function is used for running a testing environment for solving the
  millionaire's problem
  */
-int32_t test_millionaire_prob_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_millionaire_prob_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		e_sharing sharing);
 

--- a/src/examples/millionaire_prob/millionaire_prob_test.cpp
+++ b/src/examples/millionaire_prob/millionaire_prob_test.cpp
@@ -80,10 +80,10 @@ int main(int argc, char** argv) {
 	seclvl seclvl = get_sec_lvl(secparam);
 
 	//evaluate the millionaires circuit using Yao
-	test_millionaire_prob_circuit(role, (char*) address.c_str(), port, seclvl, 1, 32,
+	test_millionaire_prob_circuit(role, address, port, seclvl, 1, 32,
 			nthreads, mt_alg, S_YAO);
 	//evaluate the millionaires circuit using GMW
-	//test_millionaire_prob_circuit(role, (char*) address.c_str(), seclvl, 1, 32,
+	//test_millionaire_prob_circuit(role, address, seclvl, 1, 32,
 	//		nthreads, mt_alg, S_BOOL);
 
 	return 0;

--- a/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.cpp
+++ b/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <vector>
 
-int32_t test_min_eucliden_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t dbsize,
+int32_t test_min_eucliden_dist_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t dbsize,
 		uint32_t dim, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing dstsharing, e_sharing minsharing, ePreCompPhase pre_comp_value) {
 	uint32_t bitlen = 8, i, j, temp, tempsum, maxbitlen=32;
 	uint64_t output;

--- a/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.h
+++ b/src/examples/min-euclidean-dist/common/min-euclidean-dist-circuit.h
@@ -27,7 +27,7 @@
 class BooleanCircuit;
 
 uint64_t verify_min_euclidean_dist(uint32_t** serverdb, uint32_t* clientquery, uint32_t dbsize, uint32_t dim);
-int32_t test_min_eucliden_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t dbsize, uint32_t dim,
+int32_t test_min_eucliden_dist_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t dbsize, uint32_t dim,
 		uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing dstsharing, e_sharing minsharing, ePreCompPhase pre_comp_value);
 share* build_min_euclidean_dist_circuit(share*** S, share** C, uint32_t n, uint32_t d, share** Ssqr, share* Csqr,
 		Circuit* distcirc, BooleanCircuit* mincirc, std::vector<Sharing*>& sharings, e_sharing minsharing);

--- a/src/examples/min-euclidean-dist/min-euclidean-dist.cpp
+++ b/src/examples/min-euclidean-dist/min-euclidean-dist.cpp
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
 		min_sharing = S_YAO;
 	}
 
-	test_min_eucliden_dist_circuit(role, (char*) address.c_str(), port, seclvl, nvals, dim, nthreads, mt_alg, S_ARITH, min_sharing, precomp_phase_value);
+	test_min_eucliden_dist_circuit(role, address, port, seclvl, nvals, dim, nthreads, mt_alg, S_ARITH, min_sharing, precomp_phase_value);
 
 	return 0;
 }

--- a/src/examples/psi_phasing/common/phasing_circuit.cpp
+++ b/src/examples/psi_phasing/common/phasing_circuit.cpp
@@ -22,7 +22,7 @@
 #include <math.h>
 #include <cassert>
 
-int32_t test_phasing_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_phasing_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t server_neles, uint32_t client_neles, uint32_t bitlen, double epsilon, uint32_t nthreads,
 		e_mt_gen_alg mt_alg, e_sharing sharing, int ext_stash_size, uint32_t maxbinsize,
 		uint32_t nhashfuns) {

--- a/src/examples/psi_phasing/common/phasing_circuit.h
+++ b/src/examples/psi_phasing/common/phasing_circuit.h
@@ -27,7 +27,7 @@
 #include "hashing/simple_hashing.h"
 #include <cassert>
 
-int32_t test_phasing_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_phasing_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t server_neles, uint32_t client_neles, uint32_t bitlen, double epsilon,
 		uint32_t nthreads, e_mt_gen_alg mt_alg,	e_sharing sharing, int ext_stash_size,
 		uint32_t maxbinsize, uint32_t mhashfuns);

--- a/src/examples/psi_phasing/psi_phasing.cpp
+++ b/src/examples/psi_phasing/psi_phasing.cpp
@@ -106,10 +106,10 @@ int main(int argc, char** argv) {
 	}
 
 	//if(useyao) {
-	test_phasing_circuit(role, (char*) address.c_str(), port, seclvl, server_neles, client_neles, bitlen,
+	test_phasing_circuit(role, address, port, seclvl, server_neles, client_neles, bitlen,
 			epsilon, nthreads, mt_alg, sharing, stash, maxbin, nhashfuns);
 	/*} else {
-		test_phasing_circuit(role, (char*) address.c_str(), seclvl, neles, bitlen,
+		test_phasing_circuit(role, address, seclvl, neles, bitlen,
 				epsilon, nthreads, mt_alg, S_BOOL);
 	}*/
 

--- a/src/examples/psi_scs/common/sort_compare_shuffle.cpp
+++ b/src/examples/psi_scs/common/sort_compare_shuffle.cpp
@@ -25,7 +25,7 @@ using namespace std;
 #define BUILD_WAKSMAN
 
 
-int32_t test_psi_scs_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_psi_scs_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t neles, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		uint32_t prot_version, bool verify) {
 

--- a/src/examples/psi_scs/common/sort_compare_shuffle.h
+++ b/src/examples/psi_scs/common/sort_compare_shuffle.h
@@ -25,7 +25,7 @@
 #include "../../../abycore/aby/abyparty.h"
 #include <cassert>
 
-int32_t test_psi_scs_circuit(e_role role, char* address, uint16_t port, seclvl seclvl,
+int32_t test_psi_scs_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl,
 		uint32_t nvals, uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mt_alg,
 		uint32_t prot_version, bool verify);
 vector<uint32_t> BuildSCSPSICircuit(share** shr_srv_set, share** shr_cli_set, vector<uint32_t> shr_sel_bits,

--- a/src/examples/psi_scs/psi_scs.cpp
+++ b/src/examples/psi_scs/psi_scs.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
 
 	srand(time(0));//(unsigned)time(0));
 
-	test_psi_scs_circuit(role, (char*) address.c_str(), port, seclvl, neles, bitlen, nthreads, mt_alg, prot_version, verify_output);
+	test_psi_scs_circuit(role, address, port, seclvl, neles, bitlen, nthreads, mt_alg, prot_version, verify_output);
 
 
 	cout << "PSI circuit successfully executed" << endl;

--- a/src/examples/sha1/common/sha1_circuit.cpp
+++ b/src/examples/sha1/common/sha1_circuit.cpp
@@ -22,7 +22,7 @@
 #include <ENCRYPTO_utils/crypto/crypto.h>
 #include <cstring>
 
-int32_t test_sha1_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing) {
+int32_t test_sha1_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing) {
 	uint32_t bitlen = 32;
 	uint32_t sha1bits_per_party = ABY_SHA1_INPUT_BITS/2;
 	uint32_t sha1bytes_per_party = bits_in_bytes(sha1bits_per_party);

--- a/src/examples/sha1/common/sha1_circuit.h
+++ b/src/examples/sha1/common/sha1_circuit.h
@@ -47,7 +47,7 @@ const uint32_t ABY_SHA1_K1 = 0x6ED9EBA1;
 const uint32_t ABY_SHA1_K2 = 0x8F1BBCDC;
 const uint32_t ABY_SHA1_K3 = 0xCA62C1D6;
 
-int32_t test_sha1_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing);
+int32_t test_sha1_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing);
 
 share* BuildSHA1Circuit(share* s_msgS, share* s_msgC, uint8_t* msgS, uint8_t* msgC, uint8_t* int_out, uint32_t nvals, BooleanCircuit* circ);
 share* process_block(share* s_msg, uint8_t* msg, uint8_t* tmp_int_out, share** s_h, uint32_t* h, uint32_t nvals, BooleanCircuit* circ);

--- a/src/examples/sha1/sha1_test.cpp
+++ b/src/examples/sha1/sha1_test.cpp
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
 
 	seclvl seclvl = get_sec_lvl(secparam);
 
-	test_sha1_circuit(role, (char*) address.c_str(), port, seclvl, nvals, nthreads, mt_alg, sharing);
+	test_sha1_circuit(role, address, port, seclvl, nvals, nthreads, mt_alg, sharing);
 
 	return 0;
 }

--- a/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.cpp
+++ b/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.cpp
@@ -22,7 +22,7 @@
 #include "../../../abycore/sharing/sharing.h"
 #include <ENCRYPTO_utils/crypto/crypto.h>
 
-int32_t test_min_eucliden_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t pointbitlen,
+int32_t test_min_eucliden_dist_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t pointbitlen,
         uint32_t thresbitlen, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing dstsharing, e_sharing minsharing, uint32_t n,
         bool only_yao) {
 

--- a/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.h
+++ b/src/examples/threshold_euclidean_dist_2d_simd/common/threshold-euclidean-dist.h
@@ -33,7 +33,7 @@ class BooleanCircuit;
 //        uint32_t* y2, uint32_t * res, uint32_t n, uint32_t t);
 void verify_min_euclidean_dist(uint64_t* x1, uint64_t* x2, uint64_t* y1,
         uint64_t* y2, uint64_t * res, uint32_t n, uint64_t t);
-int32_t test_min_eucliden_dist_circuit(e_role role, char* address, uint16_t port, seclvl seclvl, uint32_t dbsize, uint32_t dim,
+int32_t test_min_eucliden_dist_circuit(e_role role, const std::string& address, uint16_t port, seclvl seclvl, uint32_t dbsize, uint32_t dim,
 		uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing dstsharing, e_sharing minsharing, uint32_t n, bool only_yao);
 share* build_min_euclidean_dist_circuit(share* x1, share* y1, share* x2, share* y2,
         uint32_t n, uint64_t t, uint32_t bitlen, Circuit* distcirc, BooleanCircuit* mincirc,

--- a/src/examples/threshold_euclidean_dist_2d_simd/threshold-euclidean-dist.cpp
+++ b/src/examples/threshold_euclidean_dist_2d_simd/threshold-euclidean-dist.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
 
 	seclvl seclvl = get_sec_lvl(secparam);
 
-	test_min_eucliden_dist_circuit(role, (char*) address.c_str(), port,
+	test_min_eucliden_dist_circuit(role, address, port,
                 seclvl, pointbitlen, thresbitlen, 2, mt_alg, S_ARITH, S_YAO, n, only_yao);
 
 	return 0;


### PR DESCRIPTION
This changes the member `ABYParty::m_cAddress` to a `std::string` (was `char*`). This change is also applied to the constructor signature by using a `const string&`.
Advantages:

1. c++ instead of c style 
2. The creator of the `ABYParty` doesn't need to take care of the string's lifetime it is passing (as is the case with a `char*`, and we had problems with that)

Although this changes the API, in practice most code should continue to work without modifications because c++ accepts `char*` values for `string` arguments.
Nonetheless, I changed all the examples to use strings themselves.