### PR TITLE
Remove erroneously introduced cout << endl

### DIFF
--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -2312,7 +2312,6 @@ std::vector<uint32_t> BooleanCircuit::PutGateFromFile(const std::string filename
 					for (uint32_t i = 0; i < tokens.size(); i++) {
 						outputs.push_back(wires[tokens[i]]);
 					}
-					std::cout << std::endl;
 					break;
 				}
 			}


### PR DESCRIPTION
Was introduced in 629698db and std::ified in f6f3ade5.
This bug printed a confusing, single new line every time the function `BooleanCircuit::PutGateFromFile` was called.