### PR TITLE
Fix to check if calloc call for maxGates succeeded or not.

### DIFF
--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -34,6 +34,11 @@ void ABYCircuit::Cleanup() {
 ABYCircuit::ABYCircuit(uint32_t maxgates) {
 	m_nMaxGates = maxgates;
 	m_pGates = (GATE*) calloc(maxgates, sizeof(GATE));
+	if (!m_pGates){
+		//calloc call failed
+		std::cerr << "Failed to allocate memory for "<<maxgates<<" gates. Reduce maxgates and retry." << std::endl;
+		exit(-1);
+	}
 	m_nNextFreeGate = 0;
 	m_nMaxVectorSize = 1;
 	m_nMaxDepth = 0;


### PR DESCRIPTION
In the current code, after doing a calloc call to allocate memory for "maxgates" number of gates, there is no check in place to check if the call succeeded or not. If the call fails, m_pGates remains NULL and gives a seg fault when accessed later. Had been encountering a seg fault on my laptop when running the code with 5.2 million gates and 8 GB RAM. Same code used to run on a 32 GB machine. 

Adding a check after the calloc call to see if the call succeeded or not. If not, the program exits with an error message. 