### PR TITLE
Fix Sharing::EvaluatePrintValGate

### DIFF
--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -95,19 +95,18 @@ void Sharing::PreCompFileDelete() {
  */
 
 UGATE_T* Sharing::ReadOutputValue(uint32_t gateid, e_circuit circ_type, uint32_t* bitlen) {
-	uint32_t nvals, ugate_bits, val_offset, valbytelen;
+	uint32_t nvals, val_offset, valbytelen;
 	UGATE_T* value;
 	GATE *parentgate, *gate;
 
 	gate = m_pGates + gateid;
 	nvals = gate->nvals;
-	ugate_bits = sizeof(UGATE_T) * 8;
 
 	//in case the values are in Boolean form, reformat them.
 	switch (circ_type) {
 		case C_BOOLEAN:
 			*bitlen = gate->ingates.ningates;
-			val_offset = ceil_divide((*bitlen), ugate_bits);
+			val_offset = ceil_divide((*bitlen), GATE_T_BITS);
 			value = (UGATE_T*) calloc(val_offset * nvals, sizeof(UGATE_T));
 
 			for (uint32_t i = 0; i < *bitlen; i++) {
@@ -116,7 +115,7 @@ UGATE_T* Sharing::ReadOutputValue(uint32_t gateid, e_circuit circ_type, uint32_t
 				assert(parentgate->instantiated);
 
 				for (uint32_t j = 0; j < nvals; j++) {
-					value[i / ugate_bits + j * val_offset] += (((parentgate->gs.val[j/ugate_bits] >> (j % ugate_bits)) & 0x01) << (i % ugate_bits));
+					value[i / GATE_T_BITS + j * val_offset] += (((parentgate->gs.val[j/GATE_T_BITS] >> (j % GATE_T_BITS)) & 0x01) << (i % GATE_T_BITS));
 				}
 			}
 			break;
@@ -164,8 +163,19 @@ void Sharing::EvaluateAssertGate(uint32_t gateid, e_circuit circ_type) {
 	free(m_pGates[gateid].gs.assertval);
 }
 
+std::string hexFormattedByte(uint8_t* arr, size_t index) {
+	std::stringstream ss;
+	ss << std::setw(2) << std::setfill('0') << std::hex << (uint32_t)arr[index];
+	return ss.str();
+}
 
-
+std::string hexFormattedByteArray(uint8_t* arr, size_t len, size_t offset = 0) {
+	std::stringstream ss;
+	for(size_t j = 0; j != len; ++j) {
+		ss << hexFormattedByte(arr, offset + j);
+	}
+	return ss.str();
+}
 
 /*
  * Print the plaintext values of gates for all sharings
@@ -189,20 +199,18 @@ void Sharing::EvaluatePrintValGate(uint32_t gateid, e_circuit circ_type) {
 			std::cout << std::endl;
 		}
 	} else {// for bitlen > 64 print hex values
+		// ReadOutputValue reserves memory in full UGATE_T chunks per value...
+		size_t bytes_per_value = ceil_divide(bitlen, GATE_T_BITS) * sizeof(UGATE_T);
 		if(nvals == 1) { //for non-SIMD wires a different format is used
-			std::cout << m_pGates[gateid].gs.infostr << ": ";
-			for(uint32_t i = 0; i < ceil_divide(bitlen, 8); i++) {
-				std::cout << std::setw(2) << std::setfill('0') << (std::hex) << (uint32_t) ((uint8_t*) value)[i] << (std::dec);
-			}
-			std::cout << std::endl;
+			std::cout << m_pGates[gateid].gs.infostr << ": "
+				<< hexFormattedByteArray((uint8_t*)value, ceil_divide(bitlen, 8))
+				<< std::endl;
 		} else {
 			std::cout << m_pGates[gateid].gs.infostr << ": " << std::endl;
 			for(uint32_t i = 0; i < nvals; i++) {
-				std::cout << "[" << i << "]: ";
-				for(uint32_t j = 0; j < ceil_divide(bitlen, 8); j++) {
-					std::cout << (std::hex) << (uint32_t) ((uint8_t*) value)[i * ceil_divide(bitlen, 8) + j] << (std::dec);
-				}
-				std::cout << std::endl;
+				std::cout << "[" << i << "]: "
+					<< hexFormattedByteArray((uint8_t*)value, ceil_divide(bitlen, 8), i*bytes_per_value)
+					<< std::endl;
 			}
 		}
 	}


### PR DESCRIPTION
Sharing::ReadOutputValue reserves full UGATE_T (64bit) chunks per value.
This has to be considered when printing the array.