### PR TITLE
 add support for std::experimental::filesystem lib

### DIFF
--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -17,7 +17,16 @@
  */
 #include "boolsharing.h"
 #include "../aby/abysetup.h"
+
+#if __has_include(<filesystem>)
 #include <filesystem>
+namespace filesystem = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace filesystem = std::experimental::filesystem;
+#else
+#error "C++17 filesystem library not found"
+#endif
 
 
 void BoolSharing::Init() {
@@ -1604,16 +1613,16 @@ void BoolSharing::Reset() {
 
 	/**Checking the role and and deciding upon the file to be deleted if the precomputation values are
 	  completely used up in a Precomputation READ mode.*/
-	std::filesystem::path precomputation_file;
+	filesystem::path precomputation_file;
 	if(m_eRole == SERVER) {
 		precomputation_file = "pre_comp_server.dump";
 	} else {
 		precomputation_file = "pre_comp_client.dump";
 	}
-	if (std::filesystem::exists(precomputation_file)
-		&& (m_nFilePos >= std::filesystem::file_size(precomputation_file))
+	if (filesystem::exists(precomputation_file)
+		&& (m_nFilePos >= filesystem::file_size(precomputation_file))
 		&& (GetPreCompPhaseValue() == ePreCompRead)) {
-		std::filesystem::remove(precomputation_file);
+		filesystem::remove(precomputation_file);
 		m_nFilePos = -1;	// FIXME: m_nFilePos is unsigned ...
 	}
 
@@ -1626,7 +1635,7 @@ void BoolSharing::PreComputationPhase() {
 	ePreCompPhase phase_value = GetPreCompPhaseValue();
 
 	/**Decision of the precomputation file based on the role of executor.*/
-	std::filesystem::path filename;
+	filesystem::path filename;
 	if(m_eRole == SERVER) {
 		filename = "pre_comp_server.dump";
 	} else {
@@ -1638,7 +1647,7 @@ void BoolSharing::PreComputationPhase() {
 		return;
 	}
 	/**Check if the execution is non-Read mode or if the file to be used in READ mode doesn't exist*/
-	else if((phase_value != ePreCompRead)||(!std::filesystem::exists(filename))) {
+	else if((phase_value != ePreCompRead)||(!filesystem::exists(filename))) {
 		/**Compute the MTs normally*/
 		ComputeMTs();
 		/**Check if the mode of precomputation is store. If so store it to respective file.*/
@@ -1668,7 +1677,7 @@ void BoolSharing::StoreMTsToFile(const char *filename) {
 		Condition to check if the file already exists. If so then, the mode of write would
 		be file append.
 	*/
-	if(std::filesystem::exists(filename)) {
+	if(filesystem::exists(filename)) {
 		fp = fopen(filename, "a+b");
 	}
 	else {
@@ -1696,7 +1705,7 @@ void BoolSharing::ReadMTsFromFile(const char *filename) {
 
 	FILE *fp;
 	/**Calculate the file size*/
-	uint64_t file_size = std::filesystem::file_size(filename);
+	uint64_t file_size = filesystem::file_size(filename);
 
 	/**Variable for the storing the NUMANDSizes value from the file.*/
 	uint32_t num_and_sizes;
@@ -1766,7 +1775,7 @@ void BoolSharing::ReadMTsFromFile(const char *filename) {
 BOOL BoolSharing::isCircuitSizeLessThanOrEqualWithValueFromFile(char *filename, uint32_t in_circ_size) {
 
 	/**Check if the file already exists and if the existing is empty. If so, return false.*/
-	if(!std::filesystem::exists(filename)||std::filesystem::is_empty(filename)) {
+	if(!filesystem::exists(filename)||filesystem::is_empty(filename)) {
 		/**Returning false and reverting the precomputation mode to default.*/
 		return FALSE;
 	}

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -21,7 +21,17 @@
 #include <ENCRYPTO_utils/crypto/crypto.h>
 #include <cassert>
 #include <cstring>
+
+#if __has_include(<filesystem>)
 #include <filesystem>
+namespace filesystem = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace filesystem = std::experimental::filesystem;
+#else
+#error "C++17 filesystem library not found"
+#endif
+
 #include <iostream>
 #include <iomanip>
 
@@ -65,22 +75,22 @@ ePreCompPhase Sharing::GetPreCompPhaseValue() {
 }
 void Sharing::PreCompFileDelete() {
 	uint64_t truncation_size;
-	std::filesystem::path filename;
+	filesystem::path filename;
 	if(m_eRole == SERVER) {
 		filename = "pre_comp_server.dump";
 	} else {
 		filename = "pre_comp_client.dump";
 	}
 
-	if((std::filesystem::exists(filename))&&(GetPreCompPhaseValue() == ePreCompRead)) {
+	if((filesystem::exists(filename))&&(GetPreCompPhaseValue() == ePreCompRead)) {
 
-		if(m_nFilePos >= std::filesystem::file_size(filename)) {
-			std::filesystem::remove(filename);
+		if(m_nFilePos >= filesystem::file_size(filename)) {
+			filesystem::remove(filename);
 		}
 		else {
-			truncation_size = std::filesystem::file_size(filename) - m_nFilePos;
+			truncation_size = filesystem::file_size(filename) - m_nFilePos;
 			std::error_code ec;
-			std::filesystem::resize_file(filename, truncation_size, ec);
+			filesystem::resize_file(filename, truncation_size, ec);
 			if(ec) {
 				std::cout << "Error occured in truncate:" << ec.message() << std::endl;
 			}


### PR DESCRIPTION
Older compilers such as some GCC versions before version 8 ship the
C++17 filesystem library but only the experimental version.  To support
these compilers, we include `<filesystem>` if available, and use
`<experimental/filesystem>` as fallback.

We use the preprocessor feature `__has_include` (C++17) to check which
header is available.  This approach works for recent compilers with
(partial) C++17 support including GCC 5 or later.