### PR TITLE
Fix PutGateFromFile's INV gates

### DIFF
--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -2308,7 +2308,7 @@ std::vector<uint32_t> BooleanCircuit::PutGateFromFile(const std::string filename
 					break;
 
 				case 'I': // INV Gate
-					wires[tokens[1]] = PutINVGate(tokens[0]);
+					wires[tokens[1]] = PutINVGate(wires[tokens[0]]);
 					break;
 
 				case 'O': // List of output wires


### PR DESCRIPTION
It must read `wires[tokens[0]]`.
No circuits in `bin/circ` use an inversion gate, why this bug probably never surfaced before.