### PR TITLE
Remove redundant code in CreateGarbledTable

### DIFF
--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -669,12 +669,10 @@ void YaoServerSharing::CreateGarbledTable(GATE* ggate, uint32_t pos, GATE* gleft
 	}
 
 	//Set permutation bit
-	if((outwire_key[m_nSecParamBytes-1] & 0x01)) {
-		m_pKeyOps->XOR(outwire_key, outwire_key, m_vR.GetArr());
-		ggate->gs.yinput.pi[pos] = !(outwire_key[m_nSecParamBytes-1] & 0x01) ^ ((lpbit) & (rpbit));
-	} else {
-		ggate->gs.yinput.pi[pos] = (outwire_key[m_nSecParamBytes-1] & 0x01) ^ ((lpbit) & (rpbit));
+	if(outwire_key[m_nSecParamBytes-1] & 0x01) {
+		m_pKeyOps->XOR(outwire_key, outwire_key, m_vR.GetArr());	
 	}
+	ggate->gs.yinput.pi[pos] = lpbit & rpbit;
 
 #ifdef DEBUGYAOSERVER
 		std::cout << " encr : ";


### PR DESCRIPTION
1. Remove redundant code to make code shorter.
2. One question on line 654 and 655. What is the difference between "lpbit" and "lsbit"? When will line 655 be executed? Thanks for explanation.