### PR TITLE
Update Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,30 @@
 language: cpp
 compiler: g++
-dist: trusty
-
-before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
-  - mkdir $HOME/prefix
-  - export PATH="$HOME/prefix/bin:$PATH"
-  - wget https://cmake.org/files/v3.11/cmake-3.11.4-Linux-x86_64.sh
-  - chmod +x cmake-3.11.4-Linux-x86_64.sh
-  - ./cmake-3.11.4-Linux-x86_64.sh --prefix=$HOME/prefix --exclude-subdir --skip-license
-
-install:
-  - sudo apt-get install -qq g++-8
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
+dist: xenial
 
 addons:
   apt:
+    sources:
+    - sourceline: 'ppa:ubuntu-toolchain-r/test'
+    - sourceline: 'ppa:mhier/libboost-latest'
     packages:
+    - g++-8
+    - libboost1.67-dev
     - libgmp-dev
     - libssl-dev
+
+before_install:
+  # Install a recent CMake
+  - mkdir $HOME/prefix
+  - export PATH="$HOME/prefix/bin:$PATH"
+  - wget https://cmake.org/files/v3.12/cmake-3.12.4-Linux-x86_64.sh -O cmake_install.sh
+  - chmod +x cmake_install.sh
+  - ./cmake_install.sh --prefix=$HOME/prefix --exclude-subdir --skip-license
 
 script:
   - mkdir build_debug
   - cd build_debug
-  - cmake .. -DCMAKE_BUILD_TYPE=Debug -DABY_BUILD_EXE=On
+  - CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8 cmake .. -DCMAKE_BUILD_TYPE=Debug -DABY_BUILD_EXE=On
   - make
   - ./bin/abytest -r 0 -R &
   - ./bin/abytest -r 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - cd build_debug
   - CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8 cmake .. -DCMAKE_BUILD_TYPE=Debug -DABY_BUILD_EXE=On
   - make
-  - ./bin/abytest -r 0 -R &
+  - ./bin/abytest -r 0 &
   - ./bin/abytest -r 1
 
 notifications:


### PR DESCRIPTION
Travis has now Ubuntu 16.04 which is only 2.5 years old.  Also, Boost is
required for the latest version of ENCRYPTO_utils.

The (onesided) use of -R resulted in different input values used by
client and server. Hence, the test verification always failed.