### PR TITLE
abycircuit: fix allocation of infostr

### DIFF
--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -524,10 +524,11 @@ uint32_t ABYCircuit::PutPrintValGate(std::vector<uint32_t> in, std::string infos
 		assert(gate->nvals == m_pGates[in[i]].nvals);
 	}
 
-	char* tmp = (char*) malloc(sizeof(char*) * (infostr.size() + 1));
-	memcpy(tmp, infostr.c_str(), infostr.size());
-	tmp[infostr.size()]='\0';
-	gate->gs.infostr = (const char*) tmp;
+	// buffer is freed in Sharing::EvaluatePrintValGate
+	auto buffer = new char[infostr.size() + 1];
+	infostr.copy(buffer, infostr.size());
+	buffer[infostr.size()] = '\0';
+	gate->gs.infostr = buffer;
 
 	return m_nNextFreeGate++;
 }

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -218,7 +218,7 @@ void Sharing::EvaluatePrintValGate(uint32_t gateid, e_circuit circ_type) {
 	}
 
 	free(value);
-	free((char*) m_pGates[gateid].gs.infostr);
+	delete[] m_pGates[gateid].gs.infostr;
 }
 
 // Delete dynamically allocated gate contents depending on gate type


### PR DESCRIPTION
In ABYCircuit::PutPrintValGate, a buffer larger than necessary was
allocated for the infostr due to using `sizeof(char*)` instead of
`sizeof(char)`.

This is now fixed.  Also, we use std::string::copy instead of memcpy,
and new/delete instead of malloc/free.