### PR TITLE
Fix segfault on timeout

### DIFF
--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -544,6 +544,9 @@ BOOL ABYParty::EstablishConnection() {
 		success = ABYPartyConnect();
 
 	}
+	if (!success)
+		return false;
+
 	m_tComm->snd_std = std::make_unique<SndThread>(m_vSockets[0].get(), glock.get());
 	m_tComm->rcv_std = std::make_unique<RcvThread>(m_vSockets[0].get(), glock.get());
 
@@ -555,7 +558,7 @@ BOOL ABYParty::EstablishConnection() {
 
 	m_tComm->rcv_std->Start();
 	m_tComm->rcv_inv->Start();
-	return success;
+	return true;
 }
 
 //Interface to the connection method

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -30,6 +30,7 @@
 #include <ENCRYPTO_utils/connection.h>
 #include <ENCRYPTO_utils/thread.h>
 
+#include <cstdlib>
 #include <mutex>
 #include <sstream>
 
@@ -95,7 +96,7 @@ ABYParty::ABYParty(e_role pid, const std::string& addr, uint16_t port, seclvl se
 	StartWatch("Generating circuit", P_CIRCUIT);
 	if (!InitCircuit(bitlen, maxgates)) {
 		std::cout << "There was an while initializing the circuit, ending! " << std::endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 	StopWatch("Time for circuit generation: ", P_CIRCUIT);
 }
@@ -109,7 +110,7 @@ void ABYParty::ConnectAndBaseOTs() {
 	StartWatch("Establishing network connection: ", P_NETWORK);
 	if (!EstablishConnection()) {
 		std::cout << "There was an error during establish connection, ending! " << std::endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 	StopWatch("Time for network connect: ", P_NETWORK);
 

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "abysetup.h"
+#include <cstdlib>
 #include <iostream>
 #include <mutex>
 
@@ -28,7 +29,7 @@ ABYSetup::ABYSetup(crypto* crypt, uint32_t numThreads, e_role role, e_mt_gen_alg
 
 	if (!Init()) {
 		std::cerr << "Error in ABYSetup init" << std::endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 }
 

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 #include <string>
 #include <iostream>
@@ -742,7 +743,7 @@ void ABYCircuit::ExportGateInBristolFormat(uint32_t gateid, uint32_t& next_gate_
 	} else {
 		std::cerr << "Gate type not available in Bristol format: " << get_gate_type_name(m_pGates[gateid].type) << ". Program exits. " << std::endl;
 		outfile.close();
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 }
 

--- a/src/abycore/circuit/arithmeticcircuits.cpp
+++ b/src/abycore/circuit/arithmeticcircuits.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "arithmeticcircuits.h"
+#include <cstdlib>
 #include <cstring>
 
 
@@ -32,7 +33,7 @@ void ArithmeticCircuit::Init() {
 	} else { //m_tContext == S_YAO
 		//unknown
 		std::cerr << "Sharing type not implemented with arithmetic circuits" << std::endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 }
 

--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -19,6 +19,7 @@
 #include "booleancircuits.h"
 #include <algorithm>
 #include <cstring>
+#include <cstdlib>
 #include <fstream>
 #include <map>
 #include <string>
@@ -65,7 +66,7 @@ void BooleanCircuit::Init() {
 		m_nRoundsOUT[1] = 0; //the client already holds the output bits from the start
 	} else {
 		std::cerr << "Sharing type not implemented for Boolean circuit" << std::endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 
 	m_nB2YGates = 0;
@@ -647,7 +648,7 @@ uint32_t BooleanCircuit::PutUniversalGate(uint32_t a, uint32_t b, uint32_t op_id
 		gateid = PutUniversalGateCircuit(a, b, op_id);
 	} else {
 		std::cerr << "Context not recognized in PutUniversalGate" << std::endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 
 	return gateid;
@@ -2999,7 +3000,7 @@ std::vector<uint32_t>  BooleanCircuit::PutConvTypeGate(std::vector<uint32_t> wir
             return PutFp2UintGate(wires, (FPType*)from , (UINTType*)to);
         default: 
             std::cout <<"Unknown data type in CONVType %zu" << to << std::endl;
-            exit(EXIT_FAILURE);
+            std::exit(EXIT_FAILURE);
     }
 }
 
@@ -3118,7 +3119,7 @@ std::vector<uint32_t> BooleanCircuit::PutFp2UintGate(std::vector<uint32_t> wires
     std::vector<uint32_t> out;
     // TODO implement PutFP2INTGate
     std::cout << "PutFP2INTGate is not implemented yet" << std::endl;
-    exit(EXIT_FAILURE);
+    std::exit(EXIT_FAILURE);
     return out;
 }
 
@@ -3130,7 +3131,7 @@ std::vector<uint32_t> BooleanCircuit::PutPreOrGate(std::vector<uint32_t> wires){
     //TODO optimize circuit
     if(!wires.size()){
         std::cout << "PreORGate wires of size 0. Exitting." << std::endl;
-        exit(EXIT_FAILURE);
+        std::exit(EXIT_FAILURE);
     }
 	std::vector <uint32_t> out(wires.size());
     out[wires.size()-1] = wires[wires.size()-1];
@@ -3232,7 +3233,7 @@ share * BooleanCircuit::PutFPGate(share * in, op_t op, uint32_t nvals, fp_op_set
            break;
         default:
             std::cerr << "Wrong operation in floating point gate with one input.";
-            exit(EXIT_FAILURE);
+            std::exit(EXIT_FAILURE);
     }
     return new boolshare(PutFPGate(o, in->get_wires(),
         (uint8_t)in->get_bitlength(),
@@ -3259,7 +3260,7 @@ share * BooleanCircuit::PutFPGate(share * in_a, share * in_b, op_t op, uint32_t 
            break;
         default:
             std::cerr << "Wrong operation in floating point gate with two inputs.";
-            exit(EXIT_FAILURE);
+            std::exit(EXIT_FAILURE);
     }
     return new boolshare(PutFPGate(o, in_a->get_wires(),
                    in_b->get_wires(), (uint8_t)in_a->get_bitlength(),

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -17,6 +17,7 @@
  */
 #include "boolsharing.h"
 #include "../aby/abysetup.h"
+#include <cstdlib>
 
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -629,7 +630,7 @@ void BoolSharing::EvaluateLocalOperations(uint32_t depth) {
 			} else {
 				std::cerr << "Boolsharing: Non-interactive Operation not recognized: " << (uint32_t) gate->type
 						<< "(" << get_gate_type_name(gate->type) << "), stopping execution" << std::endl;
-				exit(0);
+				std::exit(EXIT_FAILURE);
 			}
 			break;
 		}
@@ -681,7 +682,7 @@ void BoolSharing::EvaluateInteractiveOperations(uint32_t depth) {
 		default:
 			std::cerr << "Boolsharing: Interactive Operation not recognized: " << (uint32_t) gate->type
 				<< " (" << get_gate_type_name(gate->type) << "), stopping execution" << std::endl;
-			exit(0);
+			std::exit(EXIT_FAILURE);
 		}
 	}
 }

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -21,6 +21,7 @@
 #include <ENCRYPTO_utils/crypto/crypto.h>
 #include <cassert>
 #include <cstring>
+#include <cstdlib>
 
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -144,7 +145,7 @@ UGATE_T* Sharing::ReadOutputValue(uint32_t gateid, e_circuit circ_type, uint32_t
 			break;
 		default:
 			std::cerr << "Gate type in printer gate not recognized. Stopping" << std::endl;
-			exit(0);
+			std::exit(EXIT_FAILURE);
 	}
 
 	return value;

--- a/src/abycore/sharing/splut.cpp
+++ b/src/abycore/sharing/splut.cpp
@@ -472,7 +472,7 @@ void SetupLUT::EvaluateLocalOperations(uint32_t depth) {
 			} else {
 				std::cerr << "SP-LUT: Non-interactive Operation not recognized: " << (uint32_t) gate->type
 						<< "(" << get_gate_type_name(gate->type) << "), stopping execution" << std::endl;
-				exit(0);
+				std::exit(EXIT_FAILURE);
 			}
 			break;
 		}
@@ -528,7 +528,7 @@ void SetupLUT::EvaluateInteractiveOperations(uint32_t depth) {
 		default:
 			std::cerr << "BoolNoMTSharing: Interactive Operation not recognized: " << (uint32_t) gate->type
 				<< " (" << get_gate_type_name(gate->type) << "), stopping execution" << std::endl;
-			exit(0);
+			std::exit(EXIT_FAILURE);
 		}
 	}
 }
@@ -1362,7 +1362,7 @@ void SetupLUT::GetDataToSend(std::vector<BYTE*>& sendbuf, std::vector<uint64_t>&
 			for(uint32_t j = 0; j < m_nMaskUpdateSndCtr[i].size(); j++) {
 				if(m_nChoiceUpdateSndCtr[i][j] > 0) {
 					std::cerr << "Choices should not be stashed; Something is wrong here. Exiting!" << std::endl;
-					exit(0);
+					std::exit(EXIT_FAILURE);
 				}
 				if(m_nMaskUpdateSndCtr[i][j] > 0) {
 					tmpbuf_bytes = ceil_divide(m_nMaskUpdateSndCtr[i][j], 8);

--- a/src/abycore/sharing/yaoclientsharing.cpp
+++ b/src/abycore/sharing/yaoclientsharing.cpp
@@ -17,6 +17,7 @@
  */
 #include "yaoclientsharing.h"
 #include "../aby/abysetup.h"
+#include <cstdlib>
 
 void YaoClientSharing::InitClient() {
 
@@ -205,7 +206,7 @@ void YaoClientSharing::EvaluateLocalOperations(uint32_t depth) {
 		} else {
 			std::cerr << "YaoClientSharing: Non-interactive operation not recognized: " <<
 					(uint32_t) gate->type << "(" << get_gate_type_name(gate->type) << ")" << std::endl;
-			exit(0);
+			std::exit(EXIT_FAILURE);
 		}
 	}
 }

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -18,6 +18,7 @@
 
 #include "yaoserversharing.h"
 #include "../aby/abysetup.h"
+#include <cstdlib>
 
 void YaoServerSharing::InitServer() {
 
@@ -257,7 +258,7 @@ void YaoServerSharing::EvaluateInteractiveOperations(uint32_t depth) {
 			break;
 		default:
 			std::cerr << "Interactive Operation not recognized: " << (uint32_t) gate->type << " (" << get_gate_type_name(gate->type) << "), stopping execution" << std::endl;
-			exit(0);
+			std::exit(EXIT_FAILURE);
 		}
 
 	}
@@ -428,7 +429,7 @@ void YaoServerSharing::PrecomputeGC(std::deque<uint32_t>& queue, ABYSetup* setup
 			//Do nothing since inputs are not known yet and hence no debugging can occur
 		} else {
 			std::cerr << "Operation not recognized: " << (uint32_t) gate->type << "(" << get_gate_type_name(gate->type) << ")" << std::endl;
-			exit(0);
+			std::exit(EXIT_FAILURE);
 		}
 	}
 }
@@ -1022,7 +1023,7 @@ void YaoServerSharing::InstantiateGate(GATE* gate) {
 	gate->gs.yinput.pi = (BYTE*) malloc(sizeof(BYTE) * gate->nvals);
 	if (gate->gs.yinput.outKey == NULL) {
 		std::cerr << "Memory allocation not successful at Yao gate instantiation" << std::endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 	gate->instantiated = true;
 }


### PR DESCRIPTION
Fix nullpointer dereference after connection timeout: In case establishing a connection failed, do not start Snd/RcvThreads since they try to use the given socket pointer.

Use EXIT_FAILURE as exit code instead of 0: Usually, 0 denotes a successful execution.  Hence, a different value or the standard macro EXIT_FAILURE should be used for an abort in case of an error.