### PR TITLE
use boost filesystem library for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,14 @@ find_package(GMP REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost REQUIRED)
 
+if(APPLE)
+    find_package(Boost REQUIRED COMPONENTS filesystem)
+endif()
+
 add_subdirectory(src/abycore)
 
 
 if(ABY_BUILD_EXE)
-    add_subdirectory(src/test)
     add_subdirectory(src/examples)
+    add_subdirectory(src/test)
 endif(ABY_BUILD_EXE)

--- a/src/abycore/CMakeLists.txt
+++ b/src/abycore/CMakeLists.txt
@@ -32,9 +32,15 @@ target_include_directories(aby
 # libc++.  Linking to libstdc++fs is currently required when using the
 # std::filesystem library.
 # cf. https://gitlab.kitware.com/cmake/cmake/issues/17834
-target_link_libraries(aby
-	PRIVATE stdc++fs
-)
+if (!APPLE)
+  target_link_libraries(aby
+	   PRIVATE stdc++fs
+  )
+else()
+  target_link_libraries(aby
+      PUBLIC Boost::filesystem
+  )
+endif()
 
 target_link_libraries(aby
     PUBLIC OTExtension::otextension

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -25,6 +25,9 @@ namespace filesystem = std::filesystem;
 #elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 namespace filesystem = std::experimental::filesystem;
+#elif __has_include(<boost/filesystem.hpp>)
+#include <boost/filesystem.hpp>
+namespace filesystem = boost::filesystem;
 #else
 #error "C++17 filesystem library not found"
 #endif

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -29,6 +29,10 @@ namespace filesystem = std::filesystem;
 #elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 namespace filesystem = std::experimental::filesystem;
+#elif __has_include(<boost/filesystem.hpp>)
+#define IS_BOOST_FILESYSTEM 1
+#include <boost/filesystem.hpp>
+namespace filesystem = boost::filesystem;
 #else
 #error "C++17 filesystem library not found"
 #endif
@@ -92,7 +96,11 @@ void Sharing::PreCompFileDelete() {
 		}
 		else {
 			truncation_size = filesystem::file_size(filename) - m_nFilePos;
+#if defined (IS_BOOST_FILESYSTEM)
+			boost::system::error_code ec;
+#else
 			std::error_code ec;
+#endif
 			filesystem::resize_file(filename, truncation_size, ec);
 			if(ec) {
 				std::cout << "Error occured in truncate:" << ec.message() << std::endl;


### PR DESCRIPTION
Hello,

This is a PR which makes it so ABY will build on macos without having to install another build of clang or gcc. It simplifies the process of getting it built on macos quite a bit! Hopefully the filesystem library becomes available on macos by default soon and we won't have to use the boost filesystem!

Let me know what  you think. Thanks!