### PR TITLE
~ share*->get_wires() return vector reference instead of copy

### DIFF
--- a/src/abycore/circuit/share.h
+++ b/src/abycore/circuit/share.h
@@ -45,7 +45,7 @@ public:
 	}
 	;
 
-        std::vector<uint32_t> get_wires() {
+        std::vector<uint32_t> & get_wires() {
 		return m_ngateids;
 	}
 	;


### PR DESCRIPTION
The intuitively expected behavior of get_wires() is to return a reference to the vector of wires for modifying the inside of the share. However, the current implementation returns a copy of the vector and all the changes to this vector can be propagated to the circuit only via creating a new share.