### PR TITLE
Change m_pGates GATE* C array into C++ vector<GATE>

### DIFF
--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -155,8 +155,8 @@ BOOL ABYParty::Init() {
 void ABYParty::Cleanup() {
 	// free any gates that are still instantiated
 	for(size_t i = 0; i < m_pCircuit->GetGateHead(); i++) {
-		if(m_pGates[i].instantiated) {
-			m_vSharings[0]->FreeGate(&m_pGates[i]);
+		if((*m_vGates)[i].instantiated) {
+			m_vSharings[0]->FreeGate(&(*m_vGates)[i]);
 		}
 	}
 	for(uint32_t i = 0; i < S_LAST; i++) {
@@ -298,7 +298,7 @@ BOOL ABYParty::InitCircuit(uint32_t bitlen, uint32_t maxgates) {
 	}
 	m_vSharings[S_SPLUT] = new SetupLUT(S_SPLUT, m_eRole, 1, m_pCircuit, m_cCrypt.get());
 
-	m_pGates = m_pCircuit->Gates();
+	m_vGates = &(m_pCircuit->GatesVec());
 
 #ifndef BATCH
 	std::cout << " circuit initialized..." << std::endl;
@@ -586,15 +586,15 @@ BOOL ABYParty::ABYPartyListen() {
 // TODO: are InstantiateGate and UsedGate needed in ABYParty? They don't
 // seem to get used anywhere
 void ABYParty::InstantiateGate(uint32_t gateid) {
-	m_pGates[gateid].gs.val = (UGATE_T*) malloc(sizeof(UGATE_T) * (ceil_divide(m_pGates[gateid].nvals, GATE_T_BITS)));
+	(*m_vGates)[gateid].gs.val = (UGATE_T*) malloc(sizeof(UGATE_T) * (ceil_divide((*m_vGates)[gateid].nvals, GATE_T_BITS)));
 }
 
 void ABYParty::UsedGate(uint32_t gateid) {
 	//Decrease the number of further uses of the gate
-	m_pGates[gateid].nused--;
+	(*m_vGates)[gateid].nused--;
 	//If the gate is needed in another subsequent gate, delete it
-	if (!m_pGates[gateid].nused) {
-		free(m_pGates[gateid].gs.val);
+	if (!(*m_vGates)[gateid].nused) {
+		free((*m_vGates)[gateid].gs.val);
 
 	}
 }
@@ -606,8 +606,8 @@ void ABYParty::Reset() {
 
 	// free any gates that are still instantiated
 	for(size_t i = 0; i < m_pCircuit->GetGateHead(); i++) {
-		if(m_pGates[i].instantiated) {
-			m_vSharings[0]->FreeGate(&m_pGates[i]);
+		if((*m_vGates)[i].instantiated) {
+			m_vSharings[0]->FreeGate(&(*m_vGates)[i]);
 		}
 	}
 	for (uint32_t i = 0; i < m_vSharings.size(); i++) {

--- a/src/abycore/aby/abyparty.cpp
+++ b/src/abycore/aby/abyparty.cpp
@@ -62,7 +62,7 @@ private:
 
 ABYParty::ABYParty(e_role pid, const std::string& addr, uint16_t port, seclvl seclvl,
 	uint32_t bitlen, uint32_t nthreads, e_mt_gen_alg mg_algo,
-	uint32_t maxgates)
+	uint32_t reservegates)
 	: m_cCrypt(std::make_unique<crypto>(seclvl.symbits)), glock(std::make_unique<CLock>()),
 	m_eMTGenAlg(mg_algo), m_eRole(pid), m_nNumOTThreads(nthreads),
 	m_tComm(std::make_unique<comm_ctx>()),
@@ -94,7 +94,7 @@ ABYParty::ABYParty(e_role pid, const std::string& addr, uint16_t port, seclvl se
 	std::cout << "Generating circuit" << std::endl;
 #endif
 	StartWatch("Generating circuit", P_CIRCUIT);
-	if (!InitCircuit(bitlen, maxgates)) {
+	if (!InitCircuit(bitlen, reservegates)) {
 		std::cout << "There was an while initializing the circuit, ending! " << std::endl;
 		std::exit(EXIT_FAILURE);
 	}
@@ -265,9 +265,9 @@ void ABYParty::ExecCircuit() {
 }
 
 
-BOOL ABYParty::InitCircuit(uint32_t bitlen, uint32_t maxgates) {
-	// Specification of maximum amount of gates in constructor in abyparty.h
-	m_pCircuit = new ABYCircuit(maxgates);
+BOOL ABYParty::InitCircuit(uint32_t bitlen, uint32_t reservegates) {
+	// Default reserved gates in abyparty.h constructur
+	m_pCircuit = new ABYCircuit(reservegates);
 
 	m_vSharings.resize(S_LAST);
 	m_vSharings[S_BOOL] = new BoolSharing(S_BOOL, m_eRole, 1, m_pCircuit, m_cCrypt.get());

--- a/src/abycore/aby/abyparty.h
+++ b/src/abycore/aby/abyparty.h
@@ -121,7 +121,7 @@ private:
 	uint32_t m_nMyNumInBits;
 	// Ciruit
 	ABYCircuit* m_pCircuit;
-	GATE* m_pGates;
+	std::vector<GATE>* m_vGates;
 
 	uint32_t m_nSizeOfVal;
 

--- a/src/abycore/aby/abyparty.h
+++ b/src/abycore/aby/abyparty.h
@@ -41,7 +41,7 @@ class CLock;
 class ABYParty {
 public:
 	ABYParty(e_role pid, const std::string& addr = "127.0.0.1", uint16_t port = 7766, seclvl seclvl = LT, uint32_t bitlen = 32,
-			uint32_t nthreads =	2, e_mt_gen_alg mg_algo = MT_OT, uint32_t maxgates = 4000000);
+			uint32_t nthreads =	2, e_mt_gen_alg mg_algo = MT_OT, uint32_t reservegates = 65536);
 	~ABYParty();
 
 	/**
@@ -66,7 +66,7 @@ private:
 	BOOL Init();
 	void Cleanup();
 
-	BOOL InitCircuit(uint32_t bitlen, uint32_t maxgates);
+	BOOL InitCircuit(uint32_t bitlen, uint32_t reservegates);
 
 	BOOL EstablishConnection();
 

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -29,142 +29,142 @@
 
 void ABYCircuit::Cleanup() {
 	Reset();
-	free(m_pGates);
 }
 
 ABYCircuit::ABYCircuit(uint32_t maxgates) {
-	m_nMaxGates = maxgates;
-	m_pGates = (GATE*) calloc(maxgates, sizeof(GATE));
-	m_nNextFreeGate = 0;
 	m_nMaxVectorSize = 1;
 	m_nMaxDepth = 0;
 }
 
-inline void ABYCircuit::InitGate(GATE* gate, e_gatetype type) {
+/**
+ * Gate ID of the just inserted gate
+ */
+inline uint32_t ABYCircuit::currentGateId() {
+  return m_vGates.size() - 1;
+}
+
+inline GATE* ABYCircuit::InitGate(e_gatetype type) {
 #ifdef DEBUG_CIRCUIT_CONSTRUCTION
 	std::cout << "Putting new gate with type " << type << std::endl;
 #endif
-	if(m_nNextFreeGate >= m_nMaxGates) {
-		std::cerr << "I have more gates than available: " << m_nNextFreeGate << std::endl;
-	}
-	assert(m_nNextFreeGate < m_nMaxGates);
-
-	gate->type = type;
-	gate->nused = 0;
-	gate->nrounds = 0;
+	// We abuse resize() to insert a new zero-initialized GATE struct at the end
+	// of the gate vector
+	m_vGates.resize(m_vGates.size() + 1);
+	m_vGates.back().type = type;
+	return &(m_vGates.back());
 }
 
-inline void ABYCircuit::InitGate(GATE* gate, e_gatetype type, uint32_t ina) {
-	InitGate(gate, type);
+inline GATE* ABYCircuit::InitGate(e_gatetype type, uint32_t ina) {
+	GATE* gate = InitGate(type);
 
-	assert(ina < m_nNextFreeGate);
-	gate->depth = ComputeDepth(m_pGates[ina]);
+	assert(ina < GetGateHead());
+	gate->depth = ComputeDepth(m_vGates[ina]);
 	m_nMaxDepth = std::max(m_nMaxDepth, gate->depth);
 	gate->ingates.ningates = 1;
 	gate->ingates.inputs.parent = ina;
-	gate->context = m_pGates[ina].context;
-	gate->sharebitlen = m_pGates[ina].sharebitlen;
+	gate->context = m_vGates[ina].context;
+	gate->sharebitlen = m_vGates[ina].sharebitlen;
 
 	MarkGateAsUsed(ina);
+	return gate;
 }
 
-inline void ABYCircuit::InitGate(GATE* gate, e_gatetype type, uint32_t ina, uint32_t inb) {
-	InitGate(gate, type);
+inline GATE* ABYCircuit::InitGate(e_gatetype type, uint32_t ina, uint32_t inb) {
+	GATE* gate = InitGate(type);
 
-	if(ina >= m_nNextFreeGate || inb >= m_nNextFreeGate) {
-		std::cout << "ina = " << ina << ", inb = " << inb << ", nfg = " << m_nNextFreeGate << std::endl;
-		assert(ina < m_nNextFreeGate && inb < m_nNextFreeGate);
+	if(ina >= GetGateHead() || inb >= GetGateHead()) {
+		std::cout << "ina = " << ina << ", inb = " << inb << ", nfg = " << GetGateHead() << std::endl;
+		assert(ina < GetGateHead() && inb < GetGateHead());
 
 	}
-	gate->depth = std::max(ComputeDepth(m_pGates[ina]), ComputeDepth(m_pGates[inb]));
+	gate->depth = std::max(ComputeDepth(m_vGates[ina]), ComputeDepth(m_vGates[inb]));
 	m_nMaxDepth = std::max(m_nMaxDepth, gate->depth);
 	gate->ingates.ningates = 2;
 	gate->ingates.inputs.twin.left = ina;
 	gate->ingates.inputs.twin.right = inb;
 
-	assert(m_pGates[ina].context == m_pGates[inb].context);
-	assert(m_pGates[ina].sharebitlen == m_pGates[inb].sharebitlen);
+	assert(m_vGates[ina].context == m_vGates[inb].context);
+	assert(m_vGates[ina].sharebitlen == m_vGates[inb].sharebitlen);
 
-	gate->context = m_pGates[ina].context;
-	gate->sharebitlen = m_pGates[ina].sharebitlen;
+	gate->context = m_vGates[ina].context;
+	gate->sharebitlen = m_vGates[ina].sharebitlen;
 
 	MarkGateAsUsed(ina);
 	MarkGateAsUsed(inb);
+	return gate;
 }
 
-inline void ABYCircuit::InitGate(GATE* gate, e_gatetype type, std::vector<uint32_t>& inputs) {
-	InitGate(gate, type);
+inline GATE* ABYCircuit::InitGate(e_gatetype type, std::vector<uint32_t>& inputs) {
+	GATE* gate = InitGate(type);
 	gate->ingates.ningates = inputs.size();
 	gate->depth = 0;
 
 	if (inputs.size() == 0)
-		return;
+		return gate;
 	uint32_t ina = inputs[0];
-	assert(ina < m_nNextFreeGate);
+	assert(ina < GetGateHead());
 
-	gate->depth = ComputeDepth(m_pGates[ina]);
+	gate->depth = ComputeDepth(m_vGates[ina]);
 	gate->ingates.inputs.parents = (uint32_t*) malloc(sizeof(uint32_t) * inputs.size());
 	memcpy(gate->ingates.inputs.parents, inputs.data(), inputs.size() * sizeof(uint32_t));
 
-	gate->context = m_pGates[ina].context;
-	gate->sharebitlen = m_pGates[ina].sharebitlen;
+	gate->context = m_vGates[ina].context;
+	gate->sharebitlen = m_vGates[ina].sharebitlen;
 
 	MarkGateAsUsed(ina);
 
 	for (uint32_t i = 1; i < inputs.size(); i++) {
-		assert(inputs[i] < m_nNextFreeGate);
-		gate->depth = std::max(gate->depth, ComputeDepth(m_pGates[inputs[i]]));
-		assert(gate->context == m_pGates[inputs[i]].context);
-		assert(gate->sharebitlen == m_pGates[inputs[i]].sharebitlen);
+		assert(inputs[i] < GetGateHead());
+		gate->depth = std::max(gate->depth, ComputeDepth(m_vGates[inputs[i]]));
+		assert(gate->context == m_vGates[inputs[i]].context);
+		assert(gate->sharebitlen == m_vGates[inputs[i]].sharebitlen);
 
 		MarkGateAsUsed(inputs[i]);
 	}
 	m_nMaxDepth = std::max(m_nMaxDepth, gate->depth);
+	return gate;
 }
 
-//Add a gate to m_pGates, increase the gateptr, used for G_LIN or G_NON_LIN
+//Add a gate to m_vGates, increase the gateptr, used for G_LIN or G_NON_LIN
 uint32_t ABYCircuit::PutPrimitiveGate(e_gatetype type, uint32_t inleft, uint32_t inright, uint32_t rounds) {
 
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, type, inleft, inright);
+	GATE* gate = InitGate(type, inleft, inright);
 
-	gate->nvals = std::min(m_pGates[inleft].nvals, m_pGates[inright].nvals);
+	gate->nvals = std::min(m_vGates[inleft].nvals, m_vGates[inright].nvals);
 
 	gate->nrounds = rounds;
 
 #ifdef DEBUG_CIRCUIT_CONSTRUCTION
-	std::cout << "New primitive gate with id: " << m_nNextFreeGate << ", left in = " << inleft << ", right in = " << inright << ", nvals = " << gate->nvals <<
+	std::cout << "New primitive gate with id: " << currentGateId() << ", left in = " << inleft << ", right in = " << inright << ", nvals = " << gate->nvals <<
 	", depth = " << gate->depth << ", sharingsize = " << gate->sharebitlen << ", nrounds = " << gate->nrounds << std::endl;
 #endif
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 //add a vector-MT gate, mostly the same as a standard primitive gate but with explicit choiceinput / vectorinput
 uint32_t ABYCircuit::PutNonLinearVectorGate(e_gatetype type, uint32_t choiceinput, uint32_t vectorinput, uint32_t rounds) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, type, choiceinput, vectorinput);
+	GATE* gate = InitGate(type, choiceinput, vectorinput);
 
-	assert((m_pGates[vectorinput].nvals % m_pGates[choiceinput].nvals) == 0);
+	assert((m_vGates[vectorinput].nvals % m_vGates[choiceinput].nvals) == 0);
 
-	gate->nvals = m_pGates[vectorinput].nvals;
+	gate->nvals = m_vGates[vectorinput].nvals;
 
 	gate->nrounds = rounds;
 
-	gate->gs.avs.bitlen = m_pGates[vectorinput].nvals / m_pGates[choiceinput].nvals;
+	gate->gs.avs.bitlen = m_vGates[vectorinput].nvals / m_vGates[choiceinput].nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutCombinerGate(std::vector<uint32_t> input) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_COMBINE, input);
+	GATE* gate = InitGate(G_COMBINE, input);
 
 	gate->nvals = 0;
 
 	for(uint32_t i = 0; i < input.size(); i++) {
-		//std::cout << "size at i = " << i << ": " << m_pGates[input[i]].nvals << std::endl;;
-		gate->nvals += m_pGates[input[i]].nvals;
+		//std::cout << "size at i = " << i << ": " << m_vGates[input[i]].nvals << std::endl;;
+		gate->nvals += m_vGates[input[i]].nvals;
 	}
 
 	//std::cout << "Putting combiner gate with nvals = " << gate->nvals << std::endl;
@@ -172,25 +172,24 @@ uint32_t ABYCircuit::PutCombinerGate(std::vector<uint32_t> input) {
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 //gatelenghts is defaulted to NULL
 uint32_t ABYCircuit::PutSplitterGate(uint32_t input, uint32_t pos, uint32_t bitlen) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_SPLIT, input);
+	GATE* gate = InitGate(G_SPLIT, input);
 
 	gate->gs.sinput.pos = pos;
 
 	gate->nvals = bitlen;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 //gatelenghts is defaulted to NULL
 std::vector<uint32_t> ABYCircuit::PutSplitterGate(uint32_t input, std::vector<uint32_t> bitlen) {
 
-	uint32_t nvals = m_pGates[input].nvals;
+	uint32_t nvals = m_vGates[input].nvals;
 	if(bitlen.size() == 0) {
 		bitlen.resize(nvals, 1);
 	}
@@ -198,16 +197,6 @@ std::vector<uint32_t> ABYCircuit::PutSplitterGate(uint32_t input, std::vector<ui
 
 	uint32_t ctr = 0;
 	for (uint32_t i = 0; i < bitlen.size(); i++) {
-		/*GATE* gate = m_pGates + m_nNextFreeGate;
-		outids[i] = m_nNextFreeGate;
-		InitGate(gate, G_SPLIT, input);
-
-		gate->gs.sinput.pos = ctr;
-
-		gate->nvals = 1;
-
-		ctr += gate->nvals;
-		m_nNextFreeGate++;*/
 		outids[i] = PutSplitterGate(input, ctr, bitlen[i]);
 		ctr += bitlen[i];
 		//std::cout << "bitlen[" << i << "] = " << bitlen[i] << std::endl;
@@ -220,32 +209,30 @@ std::vector<uint32_t> ABYCircuit::PutSplitterGate(uint32_t input, std::vector<ui
 }
 
 uint32_t ABYCircuit::PutCombineAtPosGate(std::vector<uint32_t> input, uint32_t pos) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_COMBINEPOS, input);
+	GATE* gate = InitGate(G_COMBINEPOS, input);
 
 	gate->nvals = input.size();
 
 	gate->gs.combinepos.pos = pos;
 
 	for (uint32_t i = 0; i < input.size(); i++) {
-		assert(pos < m_pGates[input[i]].nvals);
+		assert(pos < m_vGates[input[i]].nvals);
 	}
 
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 
 uint32_t ABYCircuit::PutSubsetGate(uint32_t input, uint32_t* posids, uint32_t nvals_out, bool copy_posids) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_SUBSET, input);
+	GATE* gate = InitGate(G_SUBSET, input);
 
 	gate->nvals = nvals_out;
 
-	//std::cout << "Putting subset gate with nvals = " << nvals << " on pos " << m_nNextFreeGate << std::endl;
-	//assert(gate->nvals <= m_pGates[input].nvals);
+	//std::cout << "Putting subset gate with nvals = " << nvals << " on pos " << currentGateId() << std::endl;
+	//assert(gate->nvals <= m_vGates[input].nvals);
 
 	gate->gs.sub_pos.copy_posids = copy_posids;
 
@@ -261,7 +248,7 @@ uint32_t ABYCircuit::PutSubsetGate(uint32_t input, uint32_t* posids, uint32_t nv
 	//std::cout << "copied" << std::endl;
 
 	//This check can be left out for performance reasons
-	uint32_t inputnvals = m_pGates[input].nvals;
+	uint32_t inputnvals = m_vGates[input].nvals;
 	for (uint32_t i = 0; i < gate->nvals; i++) {
 		assert(posids[i] < inputnvals);
 	}
@@ -269,12 +256,11 @@ uint32_t ABYCircuit::PutSubsetGate(uint32_t input, uint32_t* posids, uint32_t nv
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutStructurizedCombinerGate(std::vector<uint32_t> input, uint32_t pos_start, uint32_t pos_incr, uint32_t nvals) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_STRUCT_COMBINE, input);
+	GATE* gate = InitGate(G_STRUCT_COMBINE, input);
 
 	gate->nvals = nvals;
 
@@ -284,28 +270,27 @@ uint32_t ABYCircuit::PutStructurizedCombinerGate(std::vector<uint32_t> input, ui
 
 	/*std::cout << "From " << pos_start << " incr: " << pos_incr << " for " << nvals << " vals with max = ";
 	for (uint32_t i = 0; i < input.size(); i++) {
-		std::cout << m_pGates[input[i]].nvals << "; ";
-		//assert(pos_start + ((nvals-1) * pos_incr) <= m_pGates[input[i]].nvals);
+		std::cout << m_vGates[input[i]].nvals << "; ";
+		//assert(pos_start + ((nvals-1) * pos_incr) <= m_vGates[input[i]].nvals);
 	}
 	std::cout << std::endl;*/
 
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 
 uint32_t ABYCircuit::PutRepeaterGate(uint32_t input, uint32_t nvals) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_REPEAT, input);
+	GATE* gate = InitGate(G_REPEAT, input);
 
 	gate->nvals = nvals;
 
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 std::vector<uint32_t> ABYCircuit::PutRepeaterGate(std::vector<uint32_t> input, uint32_t nvals) {
@@ -317,68 +302,63 @@ std::vector<uint32_t> ABYCircuit::PutRepeaterGate(std::vector<uint32_t> input, u
 }
 
 uint32_t ABYCircuit::PutPermutationGate(std::vector<uint32_t> input, uint32_t* positions) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_PERM, input);
+	GATE* gate = InitGate(G_PERM, input);
 
 	gate->nvals = input.size();
 
 	gate->gs.perm.posids = (uint32_t*) malloc(sizeof(uint32_t) * gate->nvals);
 
 	for (uint32_t i = 0; i < input.size(); i++) {
-		assert(positions[i] < m_pGates[input[i]].nvals);
+		assert(positions[i] < m_vGates[input[i]].nvals);
 		gate->gs.perm.posids[i] = positions[i];
 	}
 
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutUniversalGate(uint32_t inleft, uint32_t inright, uint32_t op_id, uint32_t nrounds) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_UNIV, inleft, inright);
+	GATE* gate = InitGate(G_UNIV, inleft, inright);
 
-	gate->nvals = std::min(m_pGates[inleft].nvals, m_pGates[inright].nvals);
+	gate->nvals = std::min(m_vGates[inleft].nvals, m_vGates[inright].nvals);
 
 	gate->nrounds = nrounds;
 	gate->gs.ttable = op_id;
 
 #ifdef DEBUG_CIRCUIT_CONSTRUCTION
-	cout << "New Universal Gate with id: " << m_nNextFreeGate << ", left in = " << inleft << ", right in = " << inright << ", nvals = " << gate->nvals <<
+	cout << "New Universal Gate with id: " << currentGateId() << ", left in = " << inleft << ", right in = " << inright << ", nvals = " << gate->nvals <<
 	", depth = " << gate->depth << ", sharingsize = " << gate->sharebitlen << ", nrounds = " << gate->nrounds << ", and operation_id = " << op_id << endl;
 #endif
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutOUTGate(uint32_t in, e_role dst, uint32_t rounds) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_OUT, in);
+	GATE* gate = InitGate(G_OUT, in);
 
-	gate->nvals = m_pGates[in].nvals;
+	gate->nvals = m_vGates[in].nvals;
 
 	gate->gs.oshare.dst = dst;
 
 	gate->nrounds = rounds;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutSharedOUTGate(uint32_t in) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_SHARED_OUT, in);
+	GATE* gate = InitGate(G_SHARED_OUT, in);
 
-	gate->nvals = m_pGates[in].nvals;
+	gate->nvals = m_vGates[in].nvals;
 
 	gate->nrounds = 0;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutINGate(e_sharing context, uint32_t nvals, uint32_t sharebitlen, e_role src, uint32_t rounds) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_IN);
+	GATE* gate = InitGate(G_IN);
 	gate->nvals = nvals;
 	gate->depth = 0;
 
@@ -391,12 +371,11 @@ uint32_t ABYCircuit::PutINGate(e_sharing context, uint32_t nvals, uint32_t share
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutSharedINGate(e_sharing context, uint32_t nvals, uint32_t sharebitlen) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_SHARED_IN);
+	GATE* gate = InitGate(G_SHARED_IN);
 	gate->nvals = nvals;
 	gate->depth = 0;
 
@@ -408,13 +387,12 @@ uint32_t ABYCircuit::PutSharedINGate(e_sharing context, uint32_t nvals, uint32_t
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutConstantGate(e_sharing context, UGATE_T val, uint32_t nvals, uint32_t sharebitlen) {
 	assert(nvals > 0 && sharebitlen > 0);
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_CONSTANT);
+	GATE* gate = InitGate(G_CONSTANT);
 	gate->gs.constval = val;
 	gate->depth = 0;
 	gate->nvals = nvals;
@@ -425,31 +403,29 @@ uint32_t ABYCircuit::PutConstantGate(e_sharing context, UGATE_T val, uint32_t nv
 	if (gate->nvals > m_nMaxVectorSize)
 		m_nMaxVectorSize = gate->nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutINVGate(uint32_t in) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_INV, in);
+	GATE* gate = InitGate(G_INV, in);
 
-	gate->nvals = m_pGates[in].nvals;
+	gate->nvals = m_vGates[in].nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutCONVGate(std::vector<uint32_t> in, uint32_t nrounds, e_sharing dst, uint32_t sharebitlen) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_CONV, in);
+	GATE* gate = InitGate(G_CONV, in);
 
 	gate->sharebitlen = sharebitlen;
 	gate->context = dst;
 	gate->nrounds = nrounds;
-	gate->nvals = m_pGates[in[0]].nvals;
+	gate->nvals = m_vGates[in[0]].nvals;
 
 	for (uint32_t i = 0; i < in.size(); i++) {
-		assert(gate->nvals == m_pGates[in[i]].nvals);
+		assert(gate->nvals == m_vGates[in[i]].nvals);
 	}
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 std::vector<uint32_t> ABYCircuit::PutOUTGate(std::vector<uint32_t> in, e_role dst, uint32_t rounds) {
@@ -470,8 +446,7 @@ std::vector<uint32_t> ABYCircuit::PutSharedOUTGate(std::vector<uint32_t> in) {
 
 uint32_t ABYCircuit::PutCallbackGate(std::vector<uint32_t> in, uint32_t rounds, void (*callback)(GATE*, void*), void* infos,
 		uint32_t nvals) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_CALLBACK, in);
+	GATE* gate = InitGate(G_CALLBACK, in);
 
 	gate->gs.cbgate.callback = callback;
 	gate->gs.cbgate.infos = infos;
@@ -480,13 +455,12 @@ uint32_t ABYCircuit::PutCallbackGate(std::vector<uint32_t> in, uint32_t rounds, 
 
 	gate->nvals = nvals;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 uint32_t ABYCircuit::PutTruthTableGate(std::vector<uint32_t> in, uint32_t rounds, uint32_t out_bits,
 		uint64_t* truth_table) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_TT, in);
+	GATE* gate = InitGate(G_TT, in);
 
 	assert(in.size() < 32);
 	assert(in.size() > 0);
@@ -498,31 +472,30 @@ uint32_t ABYCircuit::PutTruthTableGate(std::vector<uint32_t> in, uint32_t rounds
 
 	gate->nrounds = rounds;
 
-	gate->nvals = m_pGates[in[0]].nvals*out_bits;
+	gate->nvals = m_vGates[in[0]].nvals*out_bits;
 	for(uint32_t i = 1; i < in.size(); i++) {
-		assert(gate->nvals/out_bits == m_pGates[in[i]].nvals);
+		assert(gate->nvals/out_bits == m_vGates[in[i]].nvals);
 	}
 
 #ifdef DEBUGBOOL_NO_MT
 	std::cout << "Putting TT gate at depth " << gate->depth << ", predec. ";
 	for(uint32_t i = 0; i < in.size(); i++) {
-		std::cout << i << ": " << get_gate_type_name(m_pGates[in[0]].type) << " has depth "
-			<< m_pGates[in[0]].depth << " and rounds " << m_pGates[in[0]].nrounds << ", ";
+		std::cout << i << ": " << get_gate_type_name(m_vGates[in[0]].type) << " has depth "
+			<< m_vGates[in[0]].depth << " and rounds " << m_vGates[in[0]].nrounds << ", ";
 	}
 	std::cout << "my nvals = " << gate->nvals << " and " << out_bits << " output bits "<< std::endl;
 #endif
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 //TODO change gs.infostr to string
 uint32_t ABYCircuit::PutPrintValGate(std::vector<uint32_t> in, std::string infostr) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_PRINT_VAL, in);
+	GATE* gate = InitGate(G_PRINT_VAL, in);
 
-	gate->nvals = m_pGates[in[0]].nvals;
+	gate->nvals = m_vGates[in[0]].nvals;
 	for(uint32_t i = 1; i < in.size(); i++) {
-		assert(gate->nvals == m_pGates[in[i]].nvals);
+		assert(gate->nvals == m_vGates[in[i]].nvals);
 	}
 
 	// buffer is freed in Sharing::EvaluatePrintValGate
@@ -531,17 +504,16 @@ uint32_t ABYCircuit::PutPrintValGate(std::vector<uint32_t> in, std::string infos
 	buffer[infostr.size()] = '\0';
 	gate->gs.infostr = buffer;
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 
 uint32_t ABYCircuit::PutAssertGate(std::vector<uint32_t> in, uint32_t bitlen, UGATE_T* assert_val) {
-	GATE* gate = m_pGates + m_nNextFreeGate;
-	InitGate(gate, G_ASSERT, in);
+	GATE* gate = InitGate(G_ASSERT, in);
 
-	gate->nvals = m_pGates[in[0]].nvals;
+	gate->nvals = m_vGates[in[0]].nvals;
 	for(uint32_t i = 1; i < in.size(); i++) {
-		assert(gate->nvals == m_pGates[in[i]].nvals);
+		assert(gate->nvals == m_vGates[in[i]].nvals);
 	}
 
 	//initialize a new block of memory and copy the assert_val into this block
@@ -549,7 +521,7 @@ uint32_t ABYCircuit::PutAssertGate(std::vector<uint32_t> in, uint32_t bitlen, UG
 	gate->gs.assertval = (UGATE_T*) calloc(ugatelen, sizeof(UGATE_T));
 	memcpy(gate->gs.assertval, assert_val, ugatelen * sizeof(UGATE_T));
 
-	return m_nNextFreeGate++;
+	return currentGateId();
 }
 
 
@@ -570,8 +542,8 @@ uint32_t ABYCircuit::PutAssertGate(std::vector<uint32_t> in, uint32_t bitlen, UG
 #ifdef DEBUGBOOL_NO_MT
 	std::cout << "Putting mutli output TT gate at depth " << gate->depth << ", predec. ";
 	for(uint32_t i = 0; i < in.size(); i++) {
-		std::cout << i << ": " << get_gate_type_name(m_pGates[in[0]].type) << " has depth "
-			<< m_pGates[in[0]].depth << " and rounds " << m_pGates[in[0]].nrounds << ", ";
+		std::cout << i << ": " << get_gate_type_name(m_vGates[in[0]].type) << " has depth "
+			<< m_vGates[in[0]].depth << " and rounds " << m_vGates[in[0]].nrounds << ", ";
 	}
 	std::cout << "my nvals = " << gate->nvals << std::endl;
 #endif
@@ -583,11 +555,11 @@ uint32_t ABYCircuit::PutAssertGate(std::vector<uint32_t> in, uint32_t bitlen, UG
 void ABYCircuit::ExportCircuitInBristolFormat(std::vector<uint32_t> ingates_client, std::vector<uint32_t> ingates_server,
 		std::vector<uint32_t> outgates, const char* filename) {
 	//Maps an ABY gate-id into a Bristol gate-id
-	std::vector<int> gate_id_map(m_nNextFreeGate, -1);
+	std::vector<int> gate_id_map(m_vGates.size(), -1);
 	//The ABY output gates are not requried and the circuit has to make sure that the output gates appear last
 	std::vector<uint32_t> outgate_map(outgates.size());
 	//There are no constants in the Bristol circuit and hence they need to be propagated using this vector. Init with -1 to show that input is not a constant.
-	std::vector<int> constant_map(m_nNextFreeGate, -1);
+	std::vector<int> constant_map(m_vGates.size(), -1);
 	//keeps track of the next free gate id in the Bristol circuit
 	uint32_t bristol_gate_ctr = 0;
 	//a temporary value for assigning the correct id to output gates
@@ -624,7 +596,7 @@ void ABYCircuit::ExportCircuitInBristolFormat(std::vector<uint32_t> ingates_clie
 
 	//Remove the ABY output gates
 	for(uint32_t i = 0; i < outgates.size(); i++) {
-		outgate_map[i] = m_pGates[outgates[i]].ingates.inputs.parent;
+		outgate_map[i] = m_vGates[outgates[i]].ingates.inputs.parent;
 	}
 
 	//Check whether any input gates are also output gates. If so, create an extra XOR gate that evaluates to zero and give the output gates again
@@ -650,8 +622,8 @@ void ABYCircuit::ExportCircuitInBristolFormat(std::vector<uint32_t> ingates_clie
 
 	total_bristol_gates = bristol_gate_ctr + n_in_out_gates;
 	//count the total number of gates in the Bristol circuit prior to printing the circuit
-	for(uint32_t i = 0; i < m_nNextFreeGate; i++) {
-		if(m_pGates[i].type == G_LIN || m_pGates[i].type == G_NON_LIN || m_pGates[i].type == G_INV) {
+	for(uint32_t i = 0; i < m_vGates.size(); i++) {
+		if(m_vGates[i].type == G_LIN || m_vGates[i].type == G_NON_LIN || m_vGates[i].type == G_INV) {
 			total_bristol_gates++;
 		}
 	}
@@ -683,7 +655,7 @@ void ABYCircuit::ExportCircuitInBristolFormat(std::vector<uint32_t> ingates_clie
 	}
 
 	//Now go through all gates in the ABY circuit
-	for(uint32_t i = 0; i < m_nNextFreeGate; i++) {
+	for(uint32_t i = 0; i < m_vGates.size(); i++) {
 		out_gate_present = false;
 		//skip the output gates since they need to be in order for the Bristol file format
 		for(uint32_t j = 0; j < outgate_map.size(); j++) {
@@ -707,41 +679,41 @@ void ABYCircuit::ExportCircuitInBristolFormat(std::vector<uint32_t> ingates_clie
 
 void ABYCircuit::ExportGateInBristolFormat(uint32_t gateid, uint32_t& next_gate_id, std::vector<int>& gate_id_map,
 		std::vector<int>& constant_map, std::ofstream& outfile) {
-	if(m_pGates[gateid].type == G_IN) {
+	if(m_vGates[gateid].type == G_IN) {
 				//Ignore input gates
-	} else if(m_pGates[gateid].type == G_LIN) {
+	} else if(m_vGates[gateid].type == G_LIN) {
 		//enter gate into map
-		if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] + constant_map[m_pGates[gateid].ingates.inputs.twin.right] != -2) {
+		if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] + constant_map[m_vGates[gateid].ingates.inputs.twin.right] != -2) {
 			CheckAndPropagateConstant(gateid, next_gate_id, gate_id_map, constant_map, outfile);
 		} else {
-			outfile << "2 1 " << gate_id_map[m_pGates[gateid].ingates.inputs.twin.left] << " " << gate_id_map[m_pGates[gateid].ingates.inputs.twin.right] << " " << next_gate_id << " XOR"<< std::endl;
+			outfile << "2 1 " << gate_id_map[m_vGates[gateid].ingates.inputs.twin.left] << " " << gate_id_map[m_vGates[gateid].ingates.inputs.twin.right] << " " << next_gate_id << " XOR"<< std::endl;
 			gate_id_map[gateid] = next_gate_id++;
 		}
-	} else if(m_pGates[gateid].type == G_NON_LIN) {
-		if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] + constant_map[m_pGates[gateid].ingates.inputs.twin.right] != -2) {
+	} else if(m_vGates[gateid].type == G_NON_LIN) {
+		if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] + constant_map[m_vGates[gateid].ingates.inputs.twin.right] != -2) {
 			CheckAndPropagateConstant(gateid, next_gate_id, gate_id_map, constant_map, outfile);
 		} else {
-			outfile << "2 1 " << gate_id_map[m_pGates[gateid].ingates.inputs.twin.left] << " " << gate_id_map[m_pGates[gateid].ingates.inputs.twin.right] << " " << next_gate_id << " AND"<< std::endl;
+			outfile << "2 1 " << gate_id_map[m_vGates[gateid].ingates.inputs.twin.left] << " " << gate_id_map[m_vGates[gateid].ingates.inputs.twin.right] << " " << next_gate_id << " AND"<< std::endl;
 			gate_id_map[gateid] = next_gate_id++;
 		}
-	} else if(m_pGates[gateid].type == G_INV) {
-		if(constant_map[m_pGates[gateid].ingates.inputs.parent] != -1) {
-			if(constant_map[m_pGates[gateid].ingates.inputs.parent] == 0) {
-				constant_map[gateid] = constant_map[m_pGates[gateid].ingates.inputs.parent];
+	} else if(m_vGates[gateid].type == G_INV) {
+		if(constant_map[m_vGates[gateid].ingates.inputs.parent] != -1) {
+			if(constant_map[m_vGates[gateid].ingates.inputs.parent] == 0) {
+				constant_map[gateid] = constant_map[m_vGates[gateid].ingates.inputs.parent];
 			} else {
-				constant_map[gateid] = constant_map[m_pGates[gateid].ingates.inputs.parent] ^ 1;
+				constant_map[gateid] = constant_map[m_vGates[gateid].ingates.inputs.parent] ^ 1;
 			}
 		} else {
-			outfile << "1 1 " << gate_id_map[m_pGates[gateid].ingates.inputs.parent]  << " " << next_gate_id << " INV"<< std::endl;
+			outfile << "1 1 " << gate_id_map[m_vGates[gateid].ingates.inputs.parent]  << " " << next_gate_id << " INV"<< std::endl;
 			gate_id_map[gateid] = next_gate_id++;
 		}
-	} else if(m_pGates[gateid].type == G_CONSTANT) {
-		assert(m_pGates[gateid].gs.constval == 0 || m_pGates[gateid].gs.constval == 1);
-		constant_map[gateid] = m_pGates[gateid].gs.constval;
-	} else if(m_pGates[gateid].type == G_OUT) {
+	} else if(m_vGates[gateid].type == G_CONSTANT) {
+		assert(m_vGates[gateid].gs.constval == 0 || m_vGates[gateid].gs.constval == 1);
+		constant_map[gateid] = m_vGates[gateid].gs.constval;
+	} else if(m_vGates[gateid].type == G_OUT) {
 		//Ignore input gates
 	} else {
-		std::cerr << "Gate type not available in Bristol format: " << get_gate_type_name(m_pGates[gateid].type) << ". Program exits. " << std::endl;
+		std::cerr << "Gate type not available in Bristol format: " << get_gate_type_name(m_vGates[gateid].type) << ". Program exits. " << std::endl;
 		outfile.close();
 		std::exit(EXIT_FAILURE);
 	}
@@ -751,71 +723,71 @@ void ABYCircuit::CheckAndPropagateConstant(uint32_t gateid, uint32_t& next_gate_
 		std::vector<int>& constant_map, std::ofstream& outfile) {
 
 	//both gates are constant zero
-	if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] == 0 && constant_map[m_pGates[gateid].ingates.inputs.twin.right] == 0) {
+	if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] == 0 && constant_map[m_vGates[gateid].ingates.inputs.twin.right] == 0) {
 		constant_map[gateid] = 0;
 		return;
 	}
 
 	//both gates are constant one
-	if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] + constant_map[m_pGates[gateid].ingates.inputs.twin.right] == 2) {
-		if(m_pGates[gateid].type == G_LIN) {
+	if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] + constant_map[m_vGates[gateid].ingates.inputs.twin.right] == 2) {
+		if(m_vGates[gateid].type == G_LIN) {
 			constant_map[gateid] = 0;
-		} else if( m_pGates[gateid].type == G_NON_LIN) {
+		} else if( m_vGates[gateid].type == G_NON_LIN) {
 			constant_map[gateid] = 1;
 		}
 		return;
 	}
 
 	//one gate is constant one, the second constant zero
-	if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] + constant_map[m_pGates[gateid].ingates.inputs.twin.right] == 1) {
-		if(m_pGates[gateid].type == G_LIN) {
+	if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] + constant_map[m_vGates[gateid].ingates.inputs.twin.right] == 1) {
+		if(m_vGates[gateid].type == G_LIN) {
 			constant_map[gateid] = 1;
-		} else if( m_pGates[gateid].type == G_NON_LIN) {
+		} else if( m_vGates[gateid].type == G_NON_LIN) {
 			constant_map[gateid] = 0;
 		}
 		return;
 	}
 
 	//one gate is has a constant zero, the other gate is not a constant
-	if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] + constant_map[m_pGates[gateid].ingates.inputs.twin.right] == -1) {
-		if(m_pGates[gateid].type == G_LIN) {
-			if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] == -1) {
-				gate_id_map[gateid] = gate_id_map[m_pGates[gateid].ingates.inputs.twin.left];
+	if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] + constant_map[m_vGates[gateid].ingates.inputs.twin.right] == -1) {
+		if(m_vGates[gateid].type == G_LIN) {
+			if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] == -1) {
+				gate_id_map[gateid] = gate_id_map[m_vGates[gateid].ingates.inputs.twin.left];
 			} else {
-				gate_id_map[gateid] = gate_id_map[m_pGates[gateid].ingates.inputs.twin.right];
+				gate_id_map[gateid] = gate_id_map[m_vGates[gateid].ingates.inputs.twin.right];
 			}
-		} else if( m_pGates[gateid].type == G_NON_LIN) {
+		} else if( m_vGates[gateid].type == G_NON_LIN) {
 			constant_map[gateid] = 0;
 		}
 		return;
 	}
 
 	//one gate is has a constant one, the other gate is not a constant
-	if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] + constant_map[m_pGates[gateid].ingates.inputs.twin.right] == 0) {
-		if(m_pGates[gateid].type == G_LIN) {
-			if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] == -1) {
-				outfile << "1 1 " << gate_id_map[m_pGates[gateid].ingates.inputs.twin.left]  << " " << next_gate_id << " INV"<< std::endl;
+	if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] + constant_map[m_vGates[gateid].ingates.inputs.twin.right] == 0) {
+		if(m_vGates[gateid].type == G_LIN) {
+			if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] == -1) {
+				outfile << "1 1 " << gate_id_map[m_vGates[gateid].ingates.inputs.twin.left]  << " " << next_gate_id << " INV"<< std::endl;
 				gate_id_map[gateid] = next_gate_id++;
 			} else {
-				outfile << "1 1 " << gate_id_map[m_pGates[gateid].ingates.inputs.twin.right]  << " " << next_gate_id << " INV"<< std::endl;
+				outfile << "1 1 " << gate_id_map[m_vGates[gateid].ingates.inputs.twin.right]  << " " << next_gate_id << " INV"<< std::endl;
 				gate_id_map[gateid] = next_gate_id++;
 			}
-		} else if( m_pGates[gateid].type == G_NON_LIN) {
-			if(constant_map[m_pGates[gateid].ingates.inputs.twin.left] == -1) {
-				gate_id_map[gateid] = gate_id_map[m_pGates[gateid].ingates.inputs.twin.left];
+		} else if( m_vGates[gateid].type == G_NON_LIN) {
+			if(constant_map[m_vGates[gateid].ingates.inputs.twin.left] == -1) {
+				gate_id_map[gateid] = gate_id_map[m_vGates[gateid].ingates.inputs.twin.left];
 			} else {
-				gate_id_map[gateid] = gate_id_map[m_pGates[gateid].ingates.inputs.twin.right];
+				gate_id_map[gateid] = gate_id_map[m_vGates[gateid].ingates.inputs.twin.right];
 			}
 		}
 		return;
 	}
 	//The code must have stopped before from one of the conditions
 	assert(false);
-	//std::cout << "Ran through code and missed something for " << constant_map[m_pGates[gateid].ingates.inputs.twin.left] << ", " <<  constant_map[m_pGates[gateid].ingates.inputs.twin.right] << std::endl;
+	//std::cout << "Ran through code and missed something for " << constant_map[m_vGates[gateid].ingates.inputs.twin.left] << ", " <<  constant_map[m_vGates[gateid].ingates.inputs.twin.right] << std::endl;
 }
 
 inline void ABYCircuit::MarkGateAsUsed(uint32_t gateid, uint32_t uses) {
-	m_pGates[gateid].nused += uses;
+	m_vGates[gateid].nused += uses;
 }
 
 
@@ -831,8 +803,7 @@ uint32_t FindBitLenPositionInVec(uint32_t bitlen, non_lin_vec_ctx* list, uint32_
 }
 
 void ABYCircuit::Reset() {
-	memset(m_pGates, 0, sizeof(GATE) * m_nMaxGates);
-	m_nNextFreeGate = 0;
+	m_vGates.clear();
 	m_nMaxVectorSize = 1;
 	m_nMaxDepth = 0;
 }

--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -31,9 +31,11 @@ void ABYCircuit::Cleanup() {
 	Reset();
 }
 
-ABYCircuit::ABYCircuit(uint32_t maxgates) {
-	m_nMaxVectorSize = 1;
-	m_nMaxDepth = 0;
+ABYCircuit::ABYCircuit(uint32_t reservegates) :
+	m_nMaxVectorSize{1},
+	m_nMaxDepth{0}
+{
+	m_vGates.reserve(reservegates);
 }
 
 /**

--- a/src/abycore/circuit/abycircuit.h
+++ b/src/abycore/circuit/abycircuit.h
@@ -186,7 +186,7 @@ uint32_t FindBitLenPositionInVec(uint32_t bitlen, non_lin_vec_ctx* list, uint32_
 
 class ABYCircuit {
 public:
-	ABYCircuit(uint32_t maxgates);
+	ABYCircuit(uint32_t reservegates);
 	virtual ~ABYCircuit() {
 		Cleanup();
 	}

--- a/src/abycore/circuit/abycircuit.h
+++ b/src/abycore/circuit/abycircuit.h
@@ -193,8 +193,8 @@ public:
 
 	void Cleanup();
 	void Reset();
-	GATE* Gates() {
-		return m_pGates;
+	inline std::vector<GATE>& GatesVec() {
+		return m_vGates;
 	}
 
 	uint32_t PutPrimitiveGate(e_gatetype type, uint32_t inleft, uint32_t inright, uint32_t rounds);
@@ -232,7 +232,7 @@ public:
 	uint32_t PutAssertGate(std::vector<uint32_t> in, uint32_t bitlen, UGATE_T* assert_val);
 
 	uint32_t GetGateHead() {
-		return m_nNextFreeGate;
+		return m_vGates.size();
 	}
 
 	uint32_t GetTotalDepth() {
@@ -248,11 +248,11 @@ public:
 			std::vector<uint32_t> outgates, const char* filename);
 
 private:
-
-	inline void InitGate(GATE* gate, e_gatetype type);
-	inline void InitGate(GATE* gate, e_gatetype type, uint32_t ina);
-	inline void InitGate(GATE* gate, e_gatetype type, uint32_t ina, uint32_t inb);
-	inline void InitGate(GATE* gate, e_gatetype type, std::vector<uint32_t>& inputs);
+	inline uint32_t currentGateId();
+	inline GATE* InitGate(e_gatetype type);
+	inline GATE* InitGate(e_gatetype type, uint32_t ina);
+	inline GATE* InitGate(e_gatetype type, uint32_t ina, uint32_t inb);
+	inline GATE* InitGate(e_gatetype type, std::vector<uint32_t>& inputs);
 
 	inline uint32_t GetNumRounds(e_gatetype type, e_sharing context);
 	inline void MarkGateAsUsed(uint32_t gateid, uint32_t uses = 1);
@@ -262,10 +262,8 @@ private:
 	void CheckAndPropagateConstant(uint32_t gateid, uint32_t& next_gate_id, std::vector<int>& gate_id_map,
 			std::vector<int>& constant_map, std::ofstream& outfile);
 
-	GATE* m_pGates;
-	uint32_t m_nNextFreeGate;	// points to the current first unused gate
+	std::vector<GATE> m_vGates;
 	uint32_t m_nMaxVectorSize; 	// The maximum vector size in bits, required for correctly instantiating the 0 and 1 gates
-	uint32_t m_nMaxGates; 		// Maximal number of gates that is allowed
 	uint32_t m_nMaxDepth;	// maximum depth encountered in the circuit
 };
 

--- a/src/abycore/circuit/arithmeticcircuits.cpp
+++ b/src/abycore/circuit/arithmeticcircuits.cpp
@@ -50,7 +50,7 @@ share* ArithmeticCircuit::PutMULGate(share* ina, share* inb) {
 uint32_t ArithmeticCircuit::PutMULGate(uint32_t inleft, uint32_t inright) {
 	// check if one of the inputs is a const gate and then use a MULCONST gate
 	// instead.
-	if (m_pGates[inleft].type == G_CONSTANT || m_pGates[inright].type == G_CONSTANT) {
+	if (m_vGates[inleft].type == G_CONSTANT || m_vGates[inright].type == G_CONSTANT) {
 #ifdef DEBUGARITH
 		std::cout << "MUL(" << inleft << ", " << inright <<
 			"): Constant factor present, putting a MULCONST gate instead." << std::endl;
@@ -61,9 +61,9 @@ uint32_t ArithmeticCircuit::PutMULGate(uint32_t inleft, uint32_t inright) {
 	uint32_t gateid = m_cCircuit->PutPrimitiveGate(G_NON_LIN, inleft, inright, m_nRoundsAND);
 	UpdateInteractiveQueue(gateid);
 
-	if (m_pGates[gateid].nvals != INT_MAX) {
+	if (m_vGates[gateid].nvals != INT_MAX) {
 		//TODO implement for NON_LIN_VEC
-		m_nMULs += m_pGates[gateid].nvals;
+		m_nMULs += m_vGates[gateid].nvals;
 	}
 	return gateid;
 }
@@ -76,8 +76,8 @@ share* ArithmeticCircuit::PutMULCONSTGate(share* ina, share* inb) {
 
 uint32_t ArithmeticCircuit::PutMULCONSTGate(uint32_t inleft, uint32_t inright) {
 	// One of the gates needs to be a constant gate
-	assert (m_pGates[inleft].type == G_CONSTANT || m_pGates[inright].type == G_CONSTANT);
-	if (m_pGates[inleft].type == G_CONSTANT && m_pGates[inright].type == G_CONSTANT) {
+	assert (m_vGates[inleft].type == G_CONSTANT || m_vGates[inright].type == G_CONSTANT);
+	if (m_vGates[inleft].type == G_CONSTANT && m_vGates[inright].type == G_CONSTANT) {
 		std::cerr << "MULCONST(" << inleft << "," << inright <<
 			"): Both sides are constants, consider just multiplying their values before adding them as CONST gates.\n";
 	}
@@ -119,17 +119,17 @@ uint32_t ArithmeticCircuit::PutINGate(e_role src) {
 	switch (src) {
 	case SERVER:
 		m_vInputGates[0].push_back(gateid);
-		m_vInputBits[0] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[0] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	case CLIENT:
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[1] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[1] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	case ALL:
 		m_vInputGates[0].push_back(gateid);
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[0] += (m_pGates[gateid].nvals * m_nShareBitLen);
-		m_vInputBits[1] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[0] += (m_vGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[1] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	default:
 		std::cerr << "Role not recognized" << std::endl;
@@ -151,17 +151,17 @@ uint32_t ArithmeticCircuit::PutSIMDINGate(uint32_t ninvals, e_role src) {
 	switch (src) {
 	case SERVER:
 		m_vInputGates[0].push_back(gateid);
-		m_vInputBits[0] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[0] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	case CLIENT:
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[1] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[1] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	case ALL:
 		m_vInputGates[0].push_back(gateid);
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[0] += (m_pGates[gateid].nvals * m_nShareBitLen);
-		m_vInputBits[1] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[0] += (m_vGates[gateid].nvals * m_nShareBitLen);
+		m_vInputBits[1] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	default:
 		std::cerr << "Role not recognized" << std::endl;
@@ -199,17 +199,17 @@ uint32_t ArithmeticCircuit::PutOUTGate(uint32_t parentid, e_role dst) {
 	switch (dst) {
 	case SERVER:
 		m_vOutputGates[0].push_back(gateid);
-		m_vOutputBits[0] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vOutputBits[0] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	case CLIENT:
 		m_vOutputGates[1].push_back(gateid);
-		m_vOutputBits[1] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vOutputBits[1] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	case ALL:
 		m_vOutputGates[0].push_back(gateid);
 		m_vOutputGates[1].push_back(gateid);
-		m_vOutputBits[0] += (m_pGates[gateid].nvals * m_nShareBitLen);
-		m_vOutputBits[1] += (m_pGates[gateid].nvals * m_nShareBitLen);
+		m_vOutputBits[0] += (m_vGates[gateid].nvals * m_nShareBitLen);
+		m_vOutputBits[1] += (m_vGates[gateid].nvals * m_nShareBitLen);
 		break;
 	default:
 		std::cerr << "Role not recognized" << std::endl;
@@ -251,7 +251,7 @@ uint32_t ArithmeticCircuit::PutINVGate(uint32_t parentid) {
 uint32_t ArithmeticCircuit::PutCONVGate(std::vector<uint32_t> parentids) {
 	uint32_t gateid = m_cCircuit->PutCONVGate(parentids, 2, S_ARITH, m_nShareBitLen);
 	UpdateInteractiveQueue(gateid);
-	m_nCONVGates += m_pGates[gateid].nvals * parentids.size();
+	m_nCONVGates += m_vGates[gateid].nvals * parentids.size();
 	return gateid;
 }
 
@@ -336,24 +336,24 @@ share* ArithmeticCircuit::PutB2AGate(share* ina) {
 
 //enqueue interactive gate queue
 void ArithmeticCircuit::UpdateInteractiveQueue(uint32_t gateid) {
-	if (m_pGates[gateid].depth + 1 > m_vInteractiveQueueOnLvl.size()) {
-		m_vInteractiveQueueOnLvl.resize(m_pGates[gateid].depth + 1);
-		if (m_pGates[gateid].depth + 1 > m_nMaxDepth) {
-			m_nMaxDepth = m_pGates[gateid].depth + 1;
+	if (m_vGates[gateid].depth + 1 > m_vInteractiveQueueOnLvl.size()) {
+		m_vInteractiveQueueOnLvl.resize(m_vGates[gateid].depth + 1);
+		if (m_vGates[gateid].depth + 1 > m_nMaxDepth) {
+			m_nMaxDepth = m_vGates[gateid].depth + 1;
 		}
 	}
-	m_vInteractiveQueueOnLvl[m_pGates[gateid].depth].push_back(gateid);
+	m_vInteractiveQueueOnLvl[m_vGates[gateid].depth].push_back(gateid);
 }
 
 //enqueue locally evaluated gate queue
 void ArithmeticCircuit::UpdateLocalQueue(uint32_t gateid) {
-	if (m_pGates[gateid].depth + 1 > m_vLocalQueueOnLvl.size()) {
-		m_vLocalQueueOnLvl.resize(m_pGates[gateid].depth + 1);
-		if (m_pGates[gateid].depth + 1 > m_nMaxDepth) {
-			m_nMaxDepth = m_pGates[gateid].depth + 1;
+	if (m_vGates[gateid].depth + 1 > m_vLocalQueueOnLvl.size()) {
+		m_vLocalQueueOnLvl.resize(m_vGates[gateid].depth + 1);
+		if (m_vGates[gateid].depth + 1 > m_nMaxDepth) {
+			m_nMaxDepth = m_vGates[gateid].depth + 1;
 		}
 	}
-	m_vLocalQueueOnLvl[m_pGates[gateid].depth].push_back(gateid);
+	m_vLocalQueueOnLvl[m_vGates[gateid].depth].push_back(gateid);
 }
 
 void ArithmeticCircuit::Reset() {

--- a/src/abycore/circuit/arithmeticcircuits.h
+++ b/src/abycore/circuit/arithmeticcircuits.h
@@ -51,7 +51,7 @@ public:
 	template<class T> uint32_t PutINGate(T val, e_role role){
 		uint32_t gateid = PutINGate(role);
 		if (role == m_eMyRole) {
-			GATE* gate = m_pGates + gateid;
+			GATE* gate = &(m_vGates[gateid]);
 			gate->gs.ishare.inval = (UGATE_T*) calloc(ceil_divide(1 * m_nShareBitLen, sizeof(UGATE_T) * 8), sizeof(UGATE_T));
 
 			*gate->gs.ishare.inval = (UGATE_T) val;
@@ -65,7 +65,7 @@ public:
 	template<class T> uint32_t PutSIMDINGate(uint32_t nvals, T val, e_role role) {
 		uint32_t gateid = PutSIMDINGate(nvals, role);
 		if (role == m_eMyRole) {
-			GATE* gate = m_pGates + gateid;
+			GATE* gate = &(m_vGates[gateid]);
 			gate->gs.ishare.inval = (UGATE_T*) calloc(ceil_divide(nvals * m_nShareBitLen, GATE_T_BITS), sizeof(UGATE_T));
 
 			*gate->gs.ishare.inval = (UGATE_T) val;
@@ -80,7 +80,7 @@ public:
 
 	template<class T> uint32_t PutSharedINGate(T val) {
 		uint32_t gateid = PutSharedINGate();
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.val = (UGATE_T*) calloc(ceil_divide(1 * m_nShareBitLen, GATE_T_BITS), sizeof(UGATE_T));
 
 		*gate->gs.val = (UGATE_T) val;
@@ -92,7 +92,7 @@ public:
 
 	template<class T> uint32_t PutSharedSIMDINGate(uint32_t nvals, T val) {
 		uint32_t gateid = PutSharedSIMDINGate(nvals);
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.val = (UGATE_T*) calloc(ceil_divide(nvals * m_nShareBitLen, GATE_T_BITS), sizeof(UGATE_T));
 
 		*gate->gs.val = (UGATE_T) val;
@@ -332,7 +332,7 @@ private:
 		assert(iters > 0);
 		shr->set_wire_id(0, gateid);
 
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		uint32_t sharebytelen = ceil_divide(m_nShareBitLen, 8);
 		uint32_t inbytelen = ceil_divide(bitlen, 8);
 		gate->gs.val = (UGATE_T*) calloc(nvals, PadToMultiple(sharebytelen, sizeof(UGATE_T)));
@@ -358,7 +358,7 @@ private:
 		shr->set_wire_id(0, gateid);
 
 		if (role == m_eMyRole) {
-			GATE* gate = m_pGates + gateid;
+			GATE* gate = &(m_vGates[gateid]);
 			uint32_t sharebytelen = ceil_divide(m_nShareBitLen, 8);
 			uint32_t inbytelen = ceil_divide(bitlen, 8);
 			gate->gs.ishare.inval = (UGATE_T*) calloc(nvals, PadToMultiple(sharebytelen, sizeof(UGATE_T)));

--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -110,8 +110,8 @@ uint32_t BooleanCircuit::PutANDGate(uint32_t inleft, uint32_t inright) {
 			std::cerr << "Context not recognized" << std::endl;
 		}
 
-		if (m_pGates[gateid].nvals != INT_MAX) {
-			m_vANDs[0].numgates += m_pGates[gateid].nvals;
+		if (m_vGates[gateid].nvals != INT_MAX) {
+			m_vANDs[0].numgates += m_vGates[gateid].nvals;
 		} else {
 			std::cerr << "INT_MAX not allowed as nvals" << std::endl;
 		}
@@ -149,15 +149,15 @@ uint32_t BooleanCircuit::PutVectorANDGate(uint32_t choiceinput, uint32_t vectori
 	uint32_t gateid = m_cCircuit->PutNonLinearVectorGate(G_NON_LIN_VEC, choiceinput, vectorinput, m_nRoundsAND);
 	UpdateInteractiveQueue(gateid);
 
-	//std::cout << "Putting a vector and gate between a gate with " << m_pGates[choiceinput].nvals << " and " <<
-	//		m_pGates[vectorinput].nvals << ", res gate has nvals = " << m_pGates[gateid].nvals << std::endl;
+	//std::cout << "Putting a vector and gate between a gate with " << m_vGates[choiceinput].nvals << " and " <<
+	//		m_vGates[vectorinput].nvals << ", res gate has nvals = " << m_vGates[gateid].nvals << std::endl;
 
 
-	if (m_pGates[gateid].nvals != INT_MAX) {
+	if (m_vGates[gateid].nvals != INT_MAX) {
 		//Update vector AND sizes
 		//find location of vector AND bitlength
-		//int pos = FindBitLenPositionInVec(m_pGates[gateid].nvals, m_vANDs, m_nNumANDSizes);
-		int pos = FindBitLenPositionInVec(m_pGates[gateid].gs.avs.bitlen, m_vANDs, m_nNumANDSizes);
+		//int pos = FindBitLenPositionInVec(m_vGates[gateid].nvals, m_vANDs, m_nNumANDSizes);
+		int pos = FindBitLenPositionInVec(m_vGates[gateid].gs.avs.bitlen, m_vANDs, m_nNumANDSizes);
 		if (pos == -1) {
 			//Create new entry for the bit-length
 			m_nNumANDSizes++;
@@ -165,12 +165,12 @@ uint32_t BooleanCircuit::PutVectorANDGate(uint32_t choiceinput, uint32_t vectori
 			memcpy(temp, m_vANDs, (m_nNumANDSizes - 1) * sizeof(non_lin_vec_ctx));
 			free(m_vANDs);
 			m_vANDs = temp;
-			//m_vANDs[m_nNumANDSizes - 1].bitlen = m_pGates[gateid].nvals;
-			m_vANDs[m_nNumANDSizes - 1].bitlen = m_pGates[gateid].gs.avs.bitlen;
-			m_vANDs[m_nNumANDSizes - 1].numgates = m_pGates[choiceinput].nvals; //1
+			//m_vANDs[m_nNumANDSizes - 1].bitlen = m_vGates[gateid].nvals;
+			m_vANDs[m_nNumANDSizes - 1].bitlen = m_vGates[gateid].gs.avs.bitlen;
+			m_vANDs[m_nNumANDSizes - 1].numgates = m_vGates[choiceinput].nvals; //1
 		} else {
 			//increase number of vector ANDs for this bitlength by one
-			m_vANDs[pos].numgates+=m_pGates[choiceinput].nvals;
+			m_vANDs[pos].numgates+=m_vGates[choiceinput].nvals;
 		}
 	}
 	return gateid;
@@ -184,7 +184,7 @@ uint32_t BooleanCircuit::PutXORGate(uint32_t inleft, uint32_t inright) {
 	//std::cout << "inleft = " << inleft << ", inright = " << inright << std::endl;
 	uint32_t gateid = m_cCircuit->PutPrimitiveGate(G_LIN, inleft, inright, m_nRoundsXOR);
 	UpdateLocalQueue(gateid);
-	m_nNumXORVals += m_pGates[gateid].nvals;
+	m_nNumXORVals += m_vGates[gateid].nvals;
 	m_nNumXORGates += 1;
 	return gateid;
 }
@@ -204,17 +204,17 @@ uint32_t BooleanCircuit::PutINGate(e_role src) {
 	switch (src) {
 	case SERVER:
 		m_vInputGates[0].push_back(gateid);
-		m_vInputBits[0] += m_pGates[gateid].nvals;
+		m_vInputBits[0] += m_vGates[gateid].nvals;
 		break;
 	case CLIENT:
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[1] += m_pGates[gateid].nvals;
+		m_vInputBits[1] += m_vGates[gateid].nvals;
 		break;
 	case ALL:
 		m_vInputGates[0].push_back(gateid);
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[0] += m_pGates[gateid].nvals;
-		m_vInputBits[1] += m_pGates[gateid].nvals;
+		m_vInputBits[0] += m_vGates[gateid].nvals;
+		m_vInputBits[1] += m_vGates[gateid].nvals;
 		break;
 	default:
 		std::cerr << "Role not recognized" << std::endl;
@@ -230,17 +230,17 @@ uint32_t BooleanCircuit::PutSIMDINGate(uint32_t ninvals, e_role src) {
 	switch (src) {
 	case SERVER:
 		m_vInputGates[0].push_back(gateid);
-		m_vInputBits[0] += m_pGates[gateid].nvals;
+		m_vInputBits[0] += m_vGates[gateid].nvals;
 		break;
 	case CLIENT:
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[1] += m_pGates[gateid].nvals;
+		m_vInputBits[1] += m_vGates[gateid].nvals;
 		break;
 	case ALL:
 		m_vInputGates[0].push_back(gateid);
 		m_vInputGates[1].push_back(gateid);
-		m_vInputBits[0] += m_pGates[gateid].nvals;
-		m_vInputBits[1] += m_pGates[gateid].nvals;
+		m_vInputBits[0] += m_vGates[gateid].nvals;
+		m_vInputBits[1] += m_vGates[gateid].nvals;
 		break;
 	default:
 		std::cerr << "Role not recognized" << std::endl;
@@ -285,7 +285,7 @@ uint32_t BooleanCircuit::PutINGate(uint64_t val, e_role role) {
 	uint32_t gateid = PutINGate(role);
 	if (role == m_eMyRole) {
 		//assign value
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.ishare.inval = (UGATE_T*) calloc(ceil_divide(1 * m_nShareBitLen, sizeof(UGATE_T) * 8), sizeof(UGATE_T));
 		memcpy(gate->gs.ishare.inval, &val, ceil_divide(1 * m_nShareBitLen, 8));
 
@@ -299,7 +299,7 @@ uint32_t BooleanCircuit::PutINGate(uint64_t val, e_role role) {
 uint32_t BooleanCircuit::PutSharedINGate(uint64_t val) {
 	uint32_t gateid = PutSharedINGate();
 	//assign value
-	GATE* gate = m_pGates + gateid;
+	GATE* gate = &(m_vGates[gateid]);
 	gate->gs.val = (UGATE_T*) calloc(ceil_divide(1 * m_nShareBitLen, sizeof(UGATE_T) * 8), sizeof(UGATE_T));
 	memcpy(gate->gs.val, &val, ceil_divide(1 * m_nShareBitLen, 8));
 
@@ -312,7 +312,7 @@ uint32_t BooleanCircuit::PutSIMDINGate(uint32_t nvals, uint64_t val, e_role role
 	uint32_t gateid = PutSIMDINGate(nvals, role);
 	if (role == m_eMyRole) {
 		//assign value
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.ishare.inval = (UGATE_T*) calloc(ceil_divide(nvals * m_nShareBitLen, sizeof(UGATE_T) * 8), sizeof(UGATE_T));
 		memcpy(gate->gs.ishare.inval, &val, ceil_divide(nvals * m_nShareBitLen, 8));
 
@@ -327,7 +327,7 @@ uint32_t BooleanCircuit::PutSharedSIMDINGate(uint32_t nvals, uint64_t val) {
 	uint32_t gateid = PutSharedSIMDINGate(nvals);
 
 	//assign value
-	GATE* gate = m_pGates + gateid;
+	GATE* gate = &(m_vGates[gateid]);
 	gate->gs.val = (UGATE_T*) calloc(ceil_divide(nvals * m_nShareBitLen, sizeof(UGATE_T) * 8), sizeof(UGATE_T));
 	memcpy(gate->gs.val, &val, ceil_divide(nvals * m_nShareBitLen, 8));
 
@@ -339,7 +339,7 @@ uint32_t BooleanCircuit::PutSharedSIMDINGate(uint32_t nvals, uint64_t val) {
 uint32_t BooleanCircuit::PutYaoSharedSIMDINGate(uint32_t nvals, yao_fields keys) {
 	uint32_t gateid = PutSharedSIMDINGate(nvals);
 	//assign value
-	GATE* gate = m_pGates + gateid;
+	GATE* gate = &(m_vGates[gateid]);
 	//TODO: fixed to 128-bit security atm. CHANGE
 	uint8_t keybytelen = ceil_divide(128, 8);
 	if(m_eMyRole == SERVER) {
@@ -374,17 +374,17 @@ uint32_t BooleanCircuit::PutOUTGate(uint32_t parentid, e_role dst) {
 	switch (dst) {
 	case SERVER:
 		m_vOutputGates[0].push_back(gateid);
-		m_vOutputBits[0] += m_pGates[gateid].nvals;
+		m_vOutputBits[0] += m_vGates[gateid].nvals;
 		break;
 	case CLIENT:
 		m_vOutputGates[1].push_back(gateid);
-		m_vOutputBits[1] += m_pGates[gateid].nvals;
+		m_vOutputBits[1] += m_vGates[gateid].nvals;
 		break;
 	case ALL:
 		m_vOutputGates[0].push_back(gateid);
 		m_vOutputGates[1].push_back(gateid);
-		m_vOutputBits[0] += m_pGates[gateid].nvals;
-		m_vOutputBits[1] += m_pGates[gateid].nvals;
+		m_vOutputBits[0] += m_vGates[gateid].nvals;
+		m_vOutputBits[1] += m_vGates[gateid].nvals;
 		break;
 	default:
 		std::cerr << "Role not recognized" << std::endl;
@@ -407,17 +407,17 @@ std::vector<uint32_t> BooleanCircuit::PutOUTGate(std::vector<uint32_t> parentids
 		switch (dst) {
 		case SERVER:
 			m_vOutputGates[0].push_back(gateid[i]);
-			m_vOutputBits[0] += m_pGates[gateid[i]].nvals;
+			m_vOutputBits[0] += m_vGates[gateid[i]].nvals;
 			break;
 		case CLIENT:
 			m_vOutputGates[1].push_back(gateid[i]);
-			m_vOutputBits[1] += m_pGates[gateid[i]].nvals;
+			m_vOutputBits[1] += m_vGates[gateid[i]].nvals;
 			break;
 		case ALL:
 			m_vOutputGates[0].push_back(gateid[i]);
 			m_vOutputGates[1].push_back(gateid[i]);
-			m_vOutputBits[0] += m_pGates[gateid[i]].nvals;
-			m_vOutputBits[1] += m_pGates[gateid[i]].nvals;
+			m_vOutputBits[0] += m_vGates[gateid[i]].nvals;
+			m_vOutputBits[1] += m_vGates[gateid[i]].nvals;
 			break;
 		default:
 			std::cerr << "Role not recognized" << std::endl;
@@ -525,10 +525,10 @@ share* BooleanCircuit::PutINVGate(share* parent) {
 uint32_t BooleanCircuit::PutY2BCONVGate(uint32_t parentid) {
 	std::vector<uint32_t> in(1, parentid);
 	uint32_t gateid = m_cCircuit->PutCONVGate(in, 1, S_BOOL, m_nShareBitLen);
-	m_pGates[gateid].depth++;
+	m_vGates[gateid].depth++;
 	UpdateLocalQueue(gateid);
 	//a Y input gate cannot be parent to a Y2B gate. Alternatively, put a Boolean input gate
-	assert(m_pGates[parentid].type != G_IN);
+	assert(m_vGates[parentid].type != G_IN);
 
 	return gateid;
 }
@@ -539,7 +539,7 @@ uint32_t BooleanCircuit::PutB2YCONVGate(uint32_t parentid) {
 	UpdateInteractiveQueue(gateid);
 
 	//treat similar to input gate of client and server
-	m_nB2YGates += m_pGates[gateid].nvals;
+	m_nB2YGates += m_vGates[gateid].nvals;
 
 	return gateid;
 }
@@ -547,12 +547,12 @@ uint32_t BooleanCircuit::PutB2YCONVGate(uint32_t parentid) {
 uint32_t BooleanCircuit::PutYSwitchRolesGate(uint32_t parentid) {
 	std::vector<uint32_t> in(1, parentid);
 	assert(m_eContext == S_YAO || m_eContext == S_YAO_REV);
-	assert(m_pGates[in[0]].context != m_eContext);
+	assert(m_vGates[in[0]].context != m_eContext);
 	uint32_t gateid = m_cCircuit->PutCONVGate(in, 2, m_eContext, m_nShareBitLen);
 	UpdateInteractiveQueue(gateid);
 
 	//treat similar to input gate of client and server
-	m_nYSwitchGates += m_pGates[gateid].nvals;
+	m_nYSwitchGates += m_vGates[gateid].nvals;
 
 	return gateid;
 }
@@ -597,22 +597,22 @@ share* BooleanCircuit::PutYSwitchRolesGate(share* ina) {
 }
 
 std::vector<uint32_t> BooleanCircuit::PutA2YCONVGate(std::vector<uint32_t> parentid) {
-	std::vector<uint32_t> srvshares(m_pGates[parentid[0]].sharebitlen);
-	std::vector<uint32_t> clishares(m_pGates[parentid[0]].sharebitlen);
+	std::vector<uint32_t> srvshares(m_vGates[parentid[0]].sharebitlen);
+	std::vector<uint32_t> clishares(m_vGates[parentid[0]].sharebitlen);
 
-	for (uint32_t i = 0; i < m_pGates[parentid[0]].sharebitlen; i++) {
+	for (uint32_t i = 0; i < m_vGates[parentid[0]].sharebitlen; i++) {
 		srvshares[i] = m_cCircuit->PutCONVGate(parentid, 1, S_YAO, m_nShareBitLen);
-		m_pGates[srvshares[i]].gs.pos = 2 * i;
-		m_pGates[srvshares[i]].depth++; //increase depth by 1 since yao is evaluated before arith
+		m_vGates[srvshares[i]].gs.pos = 2 * i;
+		m_vGates[srvshares[i]].depth++; //increase depth by 1 since yao is evaluated before arith
 		UpdateInteractiveQueue(srvshares[i]);
 
 		clishares[i] = m_cCircuit->PutCONVGate(parentid, 2, S_YAO, m_nShareBitLen);
-		m_pGates[clishares[i]].gs.pos = 2 * i + 1;
-		m_pGates[clishares[i]].depth++; //increase depth by 1 since yao is evaluated before arith
+		m_vGates[clishares[i]].gs.pos = 2 * i + 1;
+		m_vGates[clishares[i]].depth++; //increase depth by 1 since yao is evaluated before arith
 		UpdateInteractiveQueue(clishares[i]);
 	}
 
-	m_nA2YGates += m_pGates[parentid[0]].nvals * m_pGates[parentid[0]].sharebitlen;
+	m_nA2YGates += m_vGates[parentid[0]].nvals * m_vGates[parentid[0]].sharebitlen;
 
 
 	return PutAddGate(srvshares, clishares);
@@ -643,7 +643,7 @@ uint32_t BooleanCircuit::PutUniversalGate(uint32_t a, uint32_t b, uint32_t op_id
 	if(m_eContext == S_YAO) { //In case of Yao, put universal gate
 		gateid = m_cCircuit->PutUniversalGate(a, b, op_id, m_nRoundsAND);
 		UpdateLocalQueue(gateid);
-		m_nUNIVGates+=m_pGates[gateid].nvals;
+		m_nUNIVGates+=m_vGates[gateid].nvals;
 	} else if (m_eContext == S_BOOL) { //In case of GMW, replace universal gate by sub-circuit
 		gateid = PutUniversalGateCircuit(a, b, op_id);
 	} else {
@@ -724,7 +724,7 @@ std::vector<uint32_t> BooleanCircuit::PutTruthTableMultiOutputGate(std::vector<u
 	//Transpose truth table
 	//ttable = transposeTT(1<<in.size(), out_bits, ttable);
 	uint32_t tmpgate = PutTruthTableGate(in, out_bits, ttable);
-	std::vector<uint32_t> bitlens(out_bits, m_pGates[in[0]].nvals);
+	std::vector<uint32_t> bitlens(out_bits, m_vGates[in[0]].nvals);
 	//assert(out_bits <= 8);
 
 	std::vector<uint32_t> output = m_cCircuit->PutSplitterGate(tmpgate, bitlens);
@@ -760,8 +760,8 @@ share* BooleanCircuit::PutTruthTableGate(share* in, uint64_t* ttable) {
 //check if the len exists, otherwise allocate new and update
 void BooleanCircuit::UpdateTruthTableSizes(uint32_t len, uint32_t gateid, uint32_t out_bits) {
 	//check depth and resize if required
-	uint32_t depth = m_pGates[gateid].depth;
-	uint32_t nvals = m_pGates[gateid].nvals/out_bits;
+	uint32_t depth = m_vGates[gateid].depth;
+	uint32_t nvals = m_vGates[gateid].nvals/out_bits;
 	if(depth >= m_vTTlens.size()) {
 		uint32_t old_depth = m_vTTlens.size();
 		uint32_t nlens = m_vTTlens[0].size();
@@ -797,7 +797,7 @@ void BooleanCircuit::UpdateTruthTableSizes(uint32_t len, uint32_t gateid, uint32
 					//In case of OP-LUT, also save the truth table which is needed in the setup phase
 					if(m_eContext == S_BOOL) {
 						for(uint32_t n = 0; n < nvals; n++) {
-							m_vTTlens[depth][i][j].ttable_values.push_back(m_pGates[gateid].gs.tt.table);
+							m_vTTlens[depth][i][j].ttable_values.push_back(m_vGates[gateid].gs.tt.table);
 						}
 					}
 				}
@@ -819,7 +819,7 @@ void BooleanCircuit::UpdateTruthTableSizes(uint32_t len, uint32_t gateid, uint32
 		//In case of OP-LUT, also save the truth table which is needed in the setup phase
 		if(m_eContext == S_BOOL) {
 			for(uint32_t n = 0; n < nvals; n++) {
-				m_vTTlens[depth][old_in_lens][0].ttable_values.push_back(m_pGates[gateid].gs.tt.table);
+				m_vTTlens[depth][old_in_lens][0].ttable_values.push_back(m_vGates[gateid].gs.tt.table);
 			}
 		}
 		outs_exist = true;
@@ -839,7 +839,7 @@ void BooleanCircuit::UpdateTruthTableSizes(uint32_t len, uint32_t gateid, uint32
 		//In case of OP-LUT, also save the truth table which is needed in the setup phase
 		if(m_eContext == S_BOOL) {
 			for(uint32_t n = 0; n < nvals; n++) {
-				m_vTTlens[depth][id][old_out_lens].ttable_values.push_back(m_pGates[gateid].gs.tt.table);
+				m_vTTlens[depth][id][old_out_lens].ttable_values.push_back(m_vGates[gateid].gs.tt.table);
 			}
 		}
 		outs_exist = true;
@@ -849,26 +849,26 @@ void BooleanCircuit::UpdateTruthTableSizes(uint32_t len, uint32_t gateid, uint32
 
 //enqueue interactive gate queue
 void BooleanCircuit::UpdateInteractiveQueue(uint32_t gateid) {
-	if (m_pGates[gateid].depth + 1 > m_vInteractiveQueueOnLvl.size()) {
-		m_vInteractiveQueueOnLvl.resize(m_pGates[gateid].depth + 1);
-		if (m_pGates[gateid].depth + 1 > m_nMaxDepth) {
-			m_nMaxDepth = m_pGates[gateid].depth + 1;
+	if (m_vGates[gateid].depth + 1 > m_vInteractiveQueueOnLvl.size()) {
+		m_vInteractiveQueueOnLvl.resize(m_vGates[gateid].depth + 1);
+		if (m_vGates[gateid].depth + 1 > m_nMaxDepth) {
+			m_nMaxDepth = m_vGates[gateid].depth + 1;
 		}
 	}
-	m_vInteractiveQueueOnLvl[m_pGates[gateid].depth].push_back(gateid);
+	m_vInteractiveQueueOnLvl[m_vGates[gateid].depth].push_back(gateid);
 	m_nGates++;
 }
 
 //enqueue locally evaluated gate queue
 void BooleanCircuit::UpdateLocalQueue(uint32_t gateid) {
-	if (m_pGates[gateid].depth + 1 > m_vLocalQueueOnLvl.size()) {
+	if (m_vGates[gateid].depth + 1 > m_vLocalQueueOnLvl.size()) {
 		//std::cout << "increasing size of local queue" << std::endl;
-		m_vLocalQueueOnLvl.resize(m_pGates[gateid].depth + 1);
-		if (m_pGates[gateid].depth + 1 > m_nMaxDepth) {
-			m_nMaxDepth = m_pGates[gateid].depth + 1;
+		m_vLocalQueueOnLvl.resize(m_vGates[gateid].depth + 1);
+		if (m_vGates[gateid].depth + 1 > m_nMaxDepth) {
+			m_nMaxDepth = m_vGates[gateid].depth + 1;
 		}
 	}
-	m_vLocalQueueOnLvl[m_pGates[gateid].depth].push_back(gateid);
+	m_vLocalQueueOnLvl[m_vGates[gateid].depth].push_back(gateid);
 
 	m_nGates++;
 }
@@ -893,7 +893,7 @@ std::vector<uint32_t> BooleanCircuit::PutLeftShifterGate(std::vector<uint32_t> v
 // Only works for nvals <= 32 due to the constant gate implementation in Bool
 // sharing.
 uint32_t BooleanCircuit::PutUniversalGateCircuit(uint32_t a, uint32_t b, uint32_t op_id) {
-	uint32_t nvals = std::max(m_pGates[a].nvals, m_pGates[b].nvals);
+	uint32_t nvals = std::max(m_vGates[a].nvals, m_vGates[b].nvals);
 	assert(nvals <= 32);
 
 	uint32_t mask = 0xFFFFFFFF;
@@ -946,7 +946,7 @@ std::vector<uint32_t> BooleanCircuit::PutSizeOptimizedAddGate(std::vector<uint32
 	std::vector<uint32_t> C(rep);
 	uint32_t axc, bxc, acNbc;
 
-	C[0] = PutXORGate(a[0], a[0]);//PutConstantGate(0, m_pGates[a[0]].nvals); //the second parameter stands for the number of vals
+	C[0] = PutXORGate(a[0], a[0]);//PutConstantGate(0, m_vGates[a[0]].nvals); //the second parameter stands for the number of vals
 
 	uint32_t i = 0;
 	for (; i < rep - 1; i++) {
@@ -1022,7 +1022,7 @@ std::vector<uint32_t> BooleanCircuit::PutDepthOptimizedAddGate(std::vector<uint3
 	uint32_t id, rep = std::min(a.size(), b.size());
 	std::vector<uint32_t> out(a.size() + bCARRY);
 	std::vector<uint32_t> parity(a.size()), carry(rep), parity_zero(rep);
-	uint32_t zerogate = PutConstantGate(0, m_pGates[a[0]].nvals);
+	uint32_t zerogate = PutConstantGate(0, m_vGates[a[0]].nvals);
 	uint32_t startid = zerogate;
 	share* zero_share = new boolshare(2, this);
 	share* ina = new boolshare(2, this);
@@ -1305,7 +1305,7 @@ std::vector<uint32_t> BooleanCircuit::PutMulGate(std::vector<uint32_t> a, std::v
 	}
 
 	std::vector<std::vector<uint32_t> > vAdds(rep);
-	uint32_t zerogate = PutConstantGate(0, m_pGates[a[0]].nvals);
+	uint32_t zerogate = PutConstantGate(0, m_vGates[a[0]].nvals);
 
 	uint32_t lim = std::min(resbitlen, 2 * rep);
 
@@ -1502,11 +1502,11 @@ std::vector<std::vector<uint32_t> > BooleanCircuit::PutCSNNetwork(std::vector<st
 std::vector<uint32_t> BooleanCircuit::PutSUBGate(std::vector<uint32_t> a, std::vector<uint32_t> b, uint32_t max_bitlength) {
 	//pad with leading zeros
 	if(a.size() < max_bitlength) {
-		uint32_t zerogate = PutConstantGate(0, m_pGates[a[0]].nvals);
+		uint32_t zerogate = PutConstantGate(0, m_vGates[a[0]].nvals);
 		a.resize(max_bitlength, zerogate);
 	}
 	if(b.size() < max_bitlength) {
-		uint32_t zerogate = PutConstantGate(0, m_pGates[a[0]].nvals);
+		uint32_t zerogate = PutConstantGate(0, m_vGates[a[0]].nvals);
 		b.resize(max_bitlength, zerogate);
 	}
 
@@ -1520,7 +1520,7 @@ std::vector<uint32_t> BooleanCircuit::PutSUBGate(std::vector<uint32_t> a, std::v
 		ainv[i] = PutINVGate(a[i]);
 	}
 
-	C[0] = PutConstantGate(0, m_pGates[a[0]].nvals);
+	C[0] = PutConstantGate(0, m_vGates[a[0]].nvals);
 
 	for (i = 0; i < bitlen - 1; i++) {
 		//===================
@@ -1571,7 +1571,7 @@ uint32_t BooleanCircuit::PutGTGate(std::vector<uint32_t> a, std::vector<uint32_t
 uint32_t BooleanCircuit::PutSizeOptimizedGTGate(std::vector<uint32_t> a, std::vector<uint32_t> b) {
 	PadWithLeadingZeros(a, b);
 	uint32_t ci = 0, ci1, ac, bc, acNbc;
-	ci = PutConstantGate((UGATE_T) 0, m_pGates[a[0]].nvals);
+	ci = PutConstantGate((UGATE_T) 0, m_vGates[a[0]].nvals);
 	for (uint32_t i = 0; i < a.size(); i++, ci = ci1) {
 		ac = PutXORGate(a[i], ci);
 		bc = PutXORGate(b[i], ci);
@@ -1746,7 +1746,7 @@ share* BooleanCircuit::PutANDVecGate(share* ina, share* inb) {
 	} else {
 		//std::cout << "Putting usual AND gate" << std::endl;
 		for (uint32_t i = 0; i < rep; i++) {
-			uint32_t bvec = PutRepeaterGate(inb->get_wire_id(i), m_pGates[ina->get_wire_id(i)].nvals);
+			uint32_t bvec = PutRepeaterGate(inb->get_wire_id(i), m_vGates[ina->get_wire_id(i)].nvals);
 			out->set_wire_id(i, PutANDGate(ina->get_wire_id(i), bvec));
 		}
 	}
@@ -1765,12 +1765,12 @@ std::vector<uint32_t> BooleanCircuit::PutMUXGate(std::vector<uint32_t> a, std::v
 
 	uint32_t nvals=1;
 	for(uint32_t i = 0; i < a.size(); i++) {
-		if(m_pGates[a[i]].nvals > nvals)
-			nvals = m_pGates[a[i]].nvals;
+		if(m_vGates[a[i]].nvals > nvals)
+			nvals = m_vGates[a[i]].nvals;
 	}
 	for(uint32_t i = 0; i < b.size(); i++)
-		if(m_pGates[b[i]].nvals > nvals)
-			nvals = m_pGates[b[i]].nvals;
+		if(m_vGates[b[i]].nvals > nvals)
+			nvals = m_vGates[b[i]].nvals;
 
 	if (m_eContext == S_BOOL && vecand && nvals == 1) {
 		uint32_t avec = PutCombinerGate(a);
@@ -1819,7 +1819,7 @@ uint32_t BooleanCircuit::PutVecANDMUXGate(uint32_t a, uint32_t b, uint32_t s) {
 	if (m_eContext == S_BOOL) {
 		sab = PutVectorANDGate(s, ab);
 	} else {
-		uint32_t svec = PutRepeaterGate(s, m_pGates[ab].nvals);
+		uint32_t svec = PutRepeaterGate(s, m_vGates[ab].nvals);
 		sab = PutANDGate(svec, ab);
 	}
 	return PutXORGate(b, sab);
@@ -1936,8 +1936,8 @@ std::vector<std::vector<uint32_t> > BooleanCircuit::PutCondSwapGate(std::vector<
 		out[0] = PutSplitterGate(PutXORGate(snab, avec));
 		out[1] = PutSplitterGate(PutXORGate(snab, bvec));
 	} else {
-		if (m_pGates[s].nvals < m_pGates[a[0]].nvals)
-			svec = PutRepeaterGate(s, m_pGates[a[0]].nvals);
+		if (m_vGates[s].nvals < m_vGates[a[0]].nvals)
+			svec = PutRepeaterGate(s, m_vGates[a[0]].nvals);
 		else
 			svec = s;
 
@@ -2750,7 +2750,7 @@ void BooleanCircuit::PutMultiMUXGate(share** Sa, share** Sb, share* sel, uint32_
 	std::vector<uint32_t> inputsa, inputsb;
 	uint32_t *posids;
 	uint32_t bitlen = 0;
-	uint32_t nvals = m_pGates[sel->get_wire_id(0)].nvals;
+	uint32_t nvals = m_vGates[sel->get_wire_id(0)].nvals;
 
 	//Yao not allowed, if so just put standard muxes
 	assert(m_eContext == S_BOOL);
@@ -2821,7 +2821,7 @@ void BooleanCircuit::Reset() {
 void BooleanCircuit::PadWithLeadingZeros(std::vector<uint32_t> &a, std::vector<uint32_t> &b) {
 	uint32_t maxlen = std::max(a.size(), b.size());
 	if(a.size() != b.size()) {
-		uint32_t zerogate = PutConstantGate(0, m_pGates[a[0]].nvals);
+		uint32_t zerogate = PutConstantGate(0, m_vGates[a[0]].nvals);
 		a.resize(maxlen, zerogate);
 		b.resize(maxlen, zerogate);
 	}

--- a/src/abycore/circuit/booleancircuits.h
+++ b/src/abycore/circuit/booleancircuits.h
@@ -69,7 +69,7 @@ public:
 
 		uint32_t gateid = PutINGate(m_eMyRole);
 		//assign value
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.ishare.inval = (UGATE_T*) calloc(1 * m_nShareBitLen, sizeof(UGATE_T));
 
 		*gate->gs.ishare.inval = (UGATE_T) val;
@@ -84,7 +84,7 @@ public:
 		uint32_t gateid = PutINGate(role);
 		if (role == m_eMyRole) {
 			//assign value
-			GATE* gate = m_pGates + gateid;
+			GATE* gate = &(m_vGates[gateid]);
 			gate->gs.ishare.inval = (UGATE_T*) calloc(ceil_divide(1 * m_nShareBitLen, GATE_T_BITS), sizeof(UGATE_T));
 			memcpy(gate->gs.ishare.inval, val, ceil_divide(1 * m_nShareBitLen, 8));
 
@@ -98,7 +98,7 @@ public:
 
 		uint32_t gateid = PutSIMDINGate(ninvals, m_eMyRole);
 		//assign value
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.ishare.inval = (UGATE_T*) calloc(ninvals * m_nShareBitLen, sizeof(UGATE_T));
 
 		*gate->gs.ishare.inval = (UGATE_T) val;
@@ -111,7 +111,7 @@ public:
 		uint32_t gateid = PutSIMDINGate(ninvals, role);
 		if (role == m_eMyRole) {
 			//assign value
-			GATE* gate = m_pGates + gateid;
+			GATE* gate = &(m_vGates[gateid]);
 			gate->gs.ishare.inval = (UGATE_T*) calloc(ceil_divide(ninvals * m_nShareBitLen, GATE_T_BITS), sizeof(UGATE_T));
 			memcpy(gate->gs.ishare.inval, val, ceil_divide(ninvals * m_nShareBitLen, 8));
 			gate->instantiated = true;
@@ -125,7 +125,7 @@ public:
 
 		uint32_t gateid = PutSharedINGate();
 		//assign value
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.val = (UGATE_T*) calloc(1 * m_nShareBitLen, sizeof(UGATE_T));
 
 		*gate->gs.val = (UGATE_T) val;
@@ -138,7 +138,7 @@ public:
 		uint32_t gateid = PutSharedINGate();
 
 			//assign value
-			GATE* gate = m_pGates + gateid;
+			GATE* gate = &(m_vGates[gateid]);
 			gate->gs.val = (UGATE_T*) calloc(ceil_divide(1 * m_nShareBitLen, GATE_T_BITS), sizeof(UGATE_T));
 			memcpy(gate->gs.val, val, ceil_divide(1 * m_nShareBitLen, 8));
 
@@ -153,7 +153,7 @@ public:
 
 		uint32_t gateid = PutSharedSIMDINGate(ninvals);
 		//assign value
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.val = (UGATE_T*) calloc(ninvals * m_nShareBitLen, sizeof(UGATE_T));
 
 		*gate->gs.val = (UGATE_T) val;
@@ -165,7 +165,7 @@ public:
 	template<class T> uint32_t PutSharedSIMDINGate(uint32_t ninvals, T* val) {
 		uint32_t gateid = PutSharedSIMDINGate(ninvals);
 		//assign value
-		GATE* gate = m_pGates + gateid;
+		GATE* gate = &(m_vGates[gateid]);
 		gate->gs.val = (UGATE_T*) calloc(ceil_divide(ninvals * m_nShareBitLen, GATE_T_BITS), sizeof(UGATE_T));
 		memcpy(gate->gs.val, val, ceil_divide(ninvals * m_nShareBitLen, 8));
 		gate->instantiated = true;

--- a/src/abycore/circuit/circuit.cpp
+++ b/src/abycore/circuit/circuit.cpp
@@ -22,9 +22,6 @@
 
 
 void Circuit::Init() {
-
-	m_pGates = m_cCircuit->Gates();
-
 	m_nMaxDepth = 0;
 	m_vInputGates.resize(2);
 	m_vOutputGates.resize(2);
@@ -94,19 +91,19 @@ void Circuit::Reset() {
 }
 
 gate_specific Circuit::GetGateSpecificOutput(uint32_t gateid) {
-	assert(m_pGates[gateid].instantiated);
-	return m_pGates[gateid].gs;
+	assert(m_vGates[gateid].instantiated);
+	return m_vGates[gateid].gs;
 }
 
 uint32_t Circuit::GetOutputGateValue(uint32_t gateid, UGATE_T*& outval) {
-	assert(m_pGates[gateid].instantiated);
-	outval = m_pGates[gateid].gs.val;
-	return m_pGates[gateid].nvals;
+	assert(m_vGates[gateid].instantiated);
+	outval = m_vGates[gateid].gs.val;
+	return m_vGates[gateid].nvals;
 }
 
 UGATE_T* Circuit::GetOutputGateValue(uint32_t gateid) {
-	assert(m_pGates[gateid].instantiated);
-	return m_pGates[gateid].gs.val;
+	assert(m_vGates[gateid].instantiated);
+	return m_vGates[gateid].gs.val;
 }
 
 /* Converts a Yao share to an Arithmetic share. The boolsharing circuit needs to be from type S_BOOL! */
@@ -210,8 +207,8 @@ share* Circuit::PutCombinerGate(share* input) {
 share* Circuit::PutCombinerGate(share* ina, share* inb) {
 	assert(ina->get_circuit_type() == inb->get_circuit_type());
 	std::vector<uint32_t> wires(ina->get_bitlength() + inb->get_bitlength());
-//	std::cout << "Size on left = " << ina->get_bitlength() << " (" << m_pGates[ina->get_wire_id(0)].nvals << ") on right = " << inb->get_bitlength()
-//			<< " ("<< m_pGates[inb->get_wire_id(0)].nvals << ")" << std::endl;
+//	std::cout << "Size on left = " << ina->get_bitlength() << " (" << m_vGates[ina->get_wire_id(0)].nvals << ") on right = " << inb->get_bitlength()
+//			<< " ("<< m_vGates[inb->get_wire_id(0)].nvals << ")" << std::endl;
 
 	for(uint32_t i = 0; i < ina->get_bitlength(); i++) {
 		wires[i] = ina->get_wire_id(i);
@@ -266,7 +263,7 @@ void Circuit::UpdateLocalQueue(share* gateids) {
 share* Circuit::EnsureOutputGate(share* in) {
 	bool is_output = true;
 	for (uint32_t i = 0; i < in->get_bitlength(); i++) {
-		is_output &= (m_pGates[in->get_wire_id(i)].type == G_OUT);
+		is_output &= (m_vGates[in->get_wire_id(i)].type == G_OUT);
 	}
 
 	share* outgates = in;
@@ -329,7 +326,7 @@ share* Circuit::PutSIMDAssertGate(share* in, uint32_t nvals, uint64_t* assert_va
 
 	assert(bitlen == in->get_bitlength());
 	for (uint32_t i = 0; i < in->get_bitlength(); i++) {
-		assert(m_pGates[in->get_wire_id(i)].nvals == nvals);
+		assert(m_vGates[in->get_wire_id(i)].nvals == nvals);
 	}
 
 	uint32_t tmp = m_cCircuit->PutAssertGate(outgates->get_wires(), bitlen, (UGATE_T*) assert_val);

--- a/src/abycore/circuit/circuit.h
+++ b/src/abycore/circuit/circuit.h
@@ -74,7 +74,8 @@ class Circuit {
 
 public:
 	Circuit(ABYCircuit* aby, e_sharing context, e_role myrole, uint32_t bitlen, e_circuit circ) :
-			m_cCircuit(aby), m_eContext(context), m_eMyRole(myrole), m_nShareBitLen(bitlen), m_eCirctype(circ) {
+			m_cCircuit(aby), m_eContext(context), m_eMyRole(myrole),
+			m_nShareBitLen(bitlen), m_eCirctype(circ), m_vGates(aby->GatesVec()) {
 		Init();
 	}
 
@@ -218,13 +219,13 @@ public:
 	UGATE_T* GetOutputGateValue(uint32_t gateid);
 	uint32_t GetOutputGateValue(uint32_t gateid, UGATE_T*& outval);
 	template<class T> void GetOutputGateValueT(uint32_t gateid, T& val) {
-		assert(sizeof(T) * 8 >= m_pGates[gateid].nvals * m_nShareBitLen);
-		val = *((T*) m_pGates[gateid].gs.val);
+		assert(sizeof(T) * 8 >= m_vGates[gateid].nvals * m_nShareBitLen);
+		val = *((T*) m_vGates[gateid].gs.val);
 	}
 
 	uint32_t GetNumVals(uint32_t gateid) {
 		assert(gateid < m_cCircuit->GetGateHead());
-		return m_pGates[gateid].nvals;
+		return m_vGates[gateid].nvals;
 	}
 
 	/* Common gate-building routines */
@@ -495,7 +496,7 @@ protected:
 	share* EnsureOutputGate(share* in);
 
 	ABYCircuit* m_cCircuit; /** ABYCircuit Object  */
-	GATE* m_pGates;			/** Gates vector which stores the */
+	std::vector<GATE>& m_vGates;
 	e_sharing m_eContext;
 	e_role m_eMyRole;
 	uint32_t m_nShareBitLen;

--- a/src/abycore/sharing/sharing.h
+++ b/src/abycore/sharing/sharing.h
@@ -235,13 +235,13 @@ protected:
 	UGATE_T* ReadOutputValue(uint32_t gateid, e_circuit circ_type, uint32_t* bitlen);
 
 
-	uint32_t m_nShareBitLen; /**< Bit length of shared item. */
-	GATE* m_pGates; /**< Pointer to array of Logical Gates. */
-	ABYCircuit* m_pCircuit; /**< Circuit pointer. */
-	e_role m_eRole; /**< Role object. */
-	uint32_t m_nSecParamBytes; /**< Number of security param bytes. */
-	crypto* m_cCrypto; /**< Class that contains cryptographic routines */
 	e_sharing m_eContext; /** Which sharing is executed */
+	uint32_t m_nShareBitLen; /**< Bit length of shared item. */
+	ABYCircuit* m_pCircuit; /**< Circuit pointer. */
+	std::vector<GATE>& m_vGates; /**< Reference to vector of gates. */
+	e_role m_eRole; /**< Role object. */
+	crypto* m_cCrypto; /**< Class that contains cryptographic routines */
+	uint32_t m_nSecParamBytes; /**< Number of security param bytes. */
 	uint32_t m_nTypeBitLen; /** Bit-length of the arithmetic shares in arithsharing */
 	uint64_t m_nFilePos;/**< Variable which stores the position of the file pointer. */
 	ePreCompPhase m_ePhaseValue;/**< Variable storing the current Precomputation Mode */

--- a/src/examples/lowmc/common/lowmccircuit.cpp
+++ b/src/examples/lowmc/common/lowmccircuit.cpp
@@ -29,13 +29,13 @@ int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t por
 }
 
 int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads,
-		e_mt_gen_alg mt_alg, e_sharing sharing, LowMCParams* param, uint32_t maxgates, crypto* crypt) {
+		e_mt_gen_alg mt_alg, e_sharing sharing, LowMCParams* param, uint32_t reservegates, crypto* crypt) {
 
 	uint32_t bitlen = 32, ctr = 0, exp_key_bitlen = param->blocksize * (param->nrounds+1), zero_gate;
 
 	ABYParty* party;
-	if(maxgates > 0)
-		party = new ABYParty(role, address, port, crypt->get_seclvl(), bitlen, nthreads, mt_alg, maxgates);
+	if(reservegates > 0)
+		party = new ABYParty(role, address, port, crypt->get_seclvl(), bitlen, nthreads, mt_alg, reservegates);
 	else
 		party = new ABYParty(role, address, port, crypt->get_seclvl(), bitlen, nthreads, mt_alg);
 

--- a/src/examples/lowmc/common/lowmccircuit.h
+++ b/src/examples/lowmc/common/lowmccircuit.h
@@ -58,7 +58,7 @@ static uint32_t m_nZeroGate;
 
 int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, uint32_t statesize, uint32_t keysize,
 		uint32_t sboxes, uint32_t rounds, uint32_t maxnumgates, crypto* crypt);
-int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, LowMCParams* param, uint32_t maxgates,
+int32_t test_lowmc_circuit(e_role role, const std::string& address, uint16_t port, uint32_t nvals, uint32_t nthreads, e_mt_gen_alg mt_alg, e_sharing sharing, LowMCParams* param, uint32_t reservegates,
 		crypto* crypt);
 share* BuildLowMCCircuit(share* val, share* key, BooleanCircuit* circ, LowMCParams* param, uint32_t zerogate, crypto* crypt);
 void LowMCAddRoundKey(std::vector<uint32_t>& val, std::vector<uint32_t> key, uint32_t locmcstatesize, uint32_t round, BooleanCircuit* circ);


### PR DESCRIPTION
This PR changes the central `GATE`s data structure from the notorious `GATE* m_pGates` C array into a `std::vector<GATE> m_vGates` in the `ABYParty` class.
Since `ABYParty` as well as all specific sharing type classes (descendants of the `Circuit` class) used the `m_pGates` pointer directly, I changed all those pointers into a reference `std::vector<GATE>& m_vGates`. Note that prior to this change, the array was fixed for the whole lifetime of the `ABYCircuit` class, so it was safe to access the pointer directly. The underlying array of the `vector` wrapper may change if the vector grows, so at some places I had to change the access to a cleaner `&m_vGates[...]` access and couldn't just initialize `m_pGates` with `m_vGates.data()`.

The upside is that we don't need to know the circuit size in advance but the vector just grows as needed. However, the vector will by default reserve space for 2^16 gates on initialization. This reservation can be controlled as the last argument of the `ABYParty` contructor. It was `maxgates` before, which is not necessary any more.