### PR TITLE
Add missing return statements.

### DIFF
--- a/src/examples/psi_phasing/common/hashing/cuckoo.cpp
+++ b/src/examples/psi_phasing/common/hashing/cuckoo.cpp
@@ -174,6 +174,7 @@ void *gen_cuckoo_entries(void *ctx_void) {
 	for(i = ctx->startpos; i < ctx->endpos; i++, eleptr+=inbytelen) {
 		gen_cuckoo_entry(eleptr, ctx->cuckoo_entries + i, hs, i);
 	}
+	return nullptr;
 }
 
 

--- a/src/examples/psi_phasing/common/hashing/simple_hashing.cpp
+++ b/src/examples/psi_phasing/common/hashing/simple_hashing.cpp
@@ -121,6 +121,7 @@ void *gen_entries(void *ctx_tmp) {
 	}
 	free(tmpbuf);
 	free(address);
+	return nullptr;
 }
 
 inline void insert_element(sht_ctx* table, uint8_t* element, uint32_t* address, uint8_t* tmpbuf, hs_t* hs) {


### PR DESCRIPTION
Some functions which are supposed to return a `void*` were missing a
return statement. This can result in crashes.

This should fix #122.