### PR TITLE
Update PSI Phasing Example

### DIFF
--- a/src/examples/psi_phasing/common/hashing/cuckoo.h
+++ b/src/examples/psi_phasing/common/hashing/cuckoo.h
@@ -67,7 +67,7 @@ cuckoo_hashing(uint8_t* elements, uint32_t neles, uint32_t nbins, uint32_t bitle
 		uint32_t* perm,	uint32_t ntasks, uint8_t** stash_elements, uint32_t maxstashsize, uint32_t** stashperm, uint32_t nhashfuns,
 		prf_state_ctx* prf_state);
 //routine for generating the entries, is invoked by the threads
-void *gen_cuckoo_entries(void *ctx);
+void gen_cuckoo_entries(cuckoo_entry_gen_ctx* ctx);
 inline void gen_cuckoo_entry(uint8_t* in, cuckoo_entry_ctx* out, hs_t* hs, uint32_t ele_id);
 inline bool insert_element(cuckoo_entry_ctx** ctable, cuckoo_entry_ctx* element, uint32_t max_iterations, uint32_t nhashfuns);
 inline uint32_t compute_stash_size(uint32_t nbins, uint32_t neles);

--- a/src/examples/psi_phasing/common/hashing/simple_hashing.h
+++ b/src/examples/psi_phasing/common/hashing/simple_hashing.h
@@ -46,7 +46,7 @@ typedef struct simple_hash_entry_gen_ctx {
 uint8_t* simple_hashing(uint8_t* elements, uint32_t neles, uint32_t bitlen, uint32_t* outbitlen, uint32_t* nelesinbin, uint32_t nbins,
 		uint32_t* maxbinsize, uint32_t ntasks, uint32_t nhashfuns, prf_state_ctx* prf_state);
 //routine for generating the entries, is invoked by the threads
-void *gen_entries(void *ctx);
+void gen_entries(sheg_ctx *ctx);
 void init_hash_table(sht_ctx* table, uint32_t nelements, hs_t* hs, uint32_t maxbinsize);
 void increase_max_bin_size(sht_ctx* table, uint32_t valbytelen);
 void free_hash_table(sht_ctx* table);

--- a/src/examples/psi_phasing/common/phasing_circuit.cpp
+++ b/src/examples/psi_phasing/common/phasing_circuit.cpp
@@ -200,8 +200,8 @@ int32_t test_phasing_circuit(e_role role, const std::string& address, uint16_t p
 	free(srv_set);
 	free(cli_set);
 	free(shr_srv_hash_table);
-	free(shr_cli_hash_table);
-	free(shr_out);
+	delete shr_cli_hash_table;
+	delete shr_out;
 	free(ver_intersect);
 	free(circ_intersect);
 	free(inv_perm);

--- a/src/examples/psi_phasing/common/phasing_circuit.cpp
+++ b/src/examples/psi_phasing/common/phasing_circuit.cpp
@@ -129,7 +129,11 @@ int32_t test_phasing_circuit(e_role role, const std::string& address, uint16_t p
 	}
 
 	shr_stash_out = BuildPhasingStashCircuit(shr_srv_set, shr_cli_stash, server_neles, bitlen, maxstashsize, circ);
-	shr_stash_out = circ->PutOUTGate(shr_stash_out, CLIENT);
+	{
+		auto tmp = shr_stash_out;
+		shr_stash_out = circ->PutOUTGate(shr_stash_out, CLIENT);
+		delete tmp;
+	}
 	party->ExecCircuit();
 
 	//Only the client obtains the outputs and performs the checks
@@ -189,6 +193,7 @@ int32_t test_phasing_circuit(e_role role, const std::string& address, uint16_t p
 		for(uint32_t i = 0; i < circ_inter_ctr; i++) {
 			assert(ver_intersect[i] == circ_intersect[i]);
 		}
+		free(output);
 	}
 
 #ifdef BATCH
@@ -200,12 +205,18 @@ int32_t test_phasing_circuit(e_role role, const std::string& address, uint16_t p
 	free(srv_set);
 	free(cli_set);
 	free(shr_srv_hash_table);
+	free(shr_cli_stash);
 	delete shr_cli_hash_table;
 	delete shr_out;
+	delete shr_stash_out;
 	free(ver_intersect);
 	free(circ_intersect);
 	free(inv_perm);
 	free(stash);
+	free(client_hash_table);
+	free(server_hash_table);
+	free(stashperm);
+	delete crypt;
 
 	return 0;
 }


### PR DESCRIPTION
Use `std::thread` and `std::vector`. Fixed memory leaks.

There are still multiple(?) out-of-bound reads in connection with the variable `ver_inter_ctr` in `phasing_circuit.cpp`.