### PR TITLE
Fix Issue #124

### DIFF
--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -714,7 +714,9 @@ inline void BoolSharing::EvaluateConstantGate(uint32_t gateid) {
 			gate->gs.val[i] = ~(0L);
 		}
 	}
-	gate->gs.val[ceil_divide(gate->nvals, GATE_T_BITS)-1] &= ((1L<<(gate->nvals%64)) -1L);
+	if(gate->nvals % GATE_T_BITS != 0) {
+		gate->gs.val[ceil_divide(gate->nvals, GATE_T_BITS)-1] &= ((1L<<(gate->nvals%64)) -1L);
+	}
 #ifdef DEBUGBOOL
 		std::cout << "Constant gate value: "<< value << std::endl;
 #endif


### PR DESCRIPTION
Fixes an issue which causes the evaluation of constant gates of bool shares to skip the last 64 bits if nvals is larger than 64 and nvals is a modulo of 64.