### PR TITLE
Fix boost linking issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 
 find_package(GMP REQUIRED)
 find_package(Threads REQUIRED)
-find_package(Boost 1.66.0 REQUIRED)
+find_package(Boost 1.66.0 REQUIRED COMPONENTS thread system)
 
 add_subdirectory(src/abycore)
 


### PR DESCRIPTION
Otherwise:
`Target "aby" links to target "Boost::system" but the target was not found.
  Perhaps a find_package() call is missing for an IMPORTED target, or an
  ALIAS target is missing?`
and 
`CMake Error at src/abycore/CMakeLists.txt:1 (add_library):
  Target "aby" links to target "Boost::system" but the target was not found.
  Perhaps a find_package() call is missing for an IMPORTED target, or an
  ALIAS target is missing?`
when building ABY as external dependency