### PR TITLE
Fix for the false evaluation

### DIFF
--- a/src/abycore/aby/abyparty.h
+++ b/src/abycore/aby/abyparty.h
@@ -83,7 +83,7 @@ private:
 	void UsedGate(uint32_t gateid);
 
 	BOOL PerformInteraction();
-	BOOL ThreadSendValues();
+	BOOL ThreadSendValues(uint32_t id);
 	BOOL ThreadReceiveValues();
 
 	void PrintPerformanceStatistics();

--- a/src/abycore/aby/abysetup.cpp
+++ b/src/abycore/aby/abysetup.cpp
@@ -485,7 +485,7 @@ void ABYSetup::AddReceiveTask(BYTE* rcvbuf, uint64_t rcvbytes) {
 }
 
 BOOL ABYSetup::ThreadSendData(uint32_t threadid) {
-	m_tSetupChan->send(m_tsndtask.sndbuf, m_tsndtask.sndbytes);
+	m_tSetupChan->blocking_send(m_vThreads[threadid]->GetEvent(), m_tsndtask.sndbuf, m_tsndtask.sndbytes);
 	return true;
 }
 

--- a/src/abycore/aby/abysetup.h
+++ b/src/abycore/aby/abysetup.h
@@ -161,8 +161,8 @@ private:
 	BOOL ThreadRunKKSnd(uint32_t exec);
 	BOOL ThreadRunKKRcv(uint32_t exec);
 
-	BOOL ThreadSendData(uint32_t exec);
-	BOOL ThreadReceiveData(uint32_t exec);
+	BOOL ThreadSendData(uint32_t id);
+	BOOL ThreadReceiveData(uint32_t id);
 
 	BOOL ThreadRunPaillierMTGen(uint32_t exec);
 	BOOL ThreadRunDGKMTGen(uint32_t threadid);
@@ -219,6 +219,9 @@ private:
 			std::lock_guard<std::mutex> lock(m_eJob_mutex_);
 			m_eJob = e;
 			m_evt.Set();
+		}
+		CEvent* GetEvent() {
+			return &m_evt;
 		}
 	private:
 		void ThreadMain();


### PR DESCRIPTION
Fixed a bug which caused the communication and performance evaluation to be evaluated into the false category or not to be evaluated at all.

It fixes the issue #139.

WARNING: Before merging this commit it is mandatory to merge the commit of
https://github.com/encryptogroup/ENCRYPTO_utils/pull/18 before since this fix relies on that feature request.