### PR TITLE
Multiplexer bug causing issue #79 and Constant gate implementation change

### DIFF
--- a/src/abycore/circuit/abycircuit.cpp
+++ b/src/abycore/circuit/abycircuit.cpp
@@ -402,9 +402,9 @@ uint32_t ABYCircuit::PutConstantGate(e_sharing context, UGATE_T val, uint32_t nv
 	gate->sharebitlen = sharebitlen;
 	gate->nrounds = 0;
 
-	if (gate->nvals > m_nMaxVectorSize)
+	if(gate->nvals > m_nMaxVectorSize) {
 		m_nMaxVectorSize = gate->nvals;
-
+	}
 	return currentGateId();
 }
 

--- a/src/abycore/circuit/booleancircuits.cpp
+++ b/src/abycore/circuit/booleancircuits.cpp
@@ -1773,14 +1773,11 @@ std::vector<uint32_t> BooleanCircuit::PutVecANDMUXGate(std::vector<uint32_t> a, 
 	PadWithLeadingZeros(a, b);
 
 	std::vector<uint32_t> out(nmuxes);
-	uint32_t sab, ab;
 
 	//std::cout << "Putting Vector AND gate" << std::endl;
 
 	for (uint32_t i = 0; i < nmuxes; i++) {
-		ab = PutXORGate(a[i], b[i]);
-		sab = PutVectorANDGate(s[i], ab);
-		out[i] = PutXORGate(b[i], sab);
+		out[i] = PutVecANDMUXGate(a[i], b[i], s[i]);
 	}
 
 	return out;
@@ -1793,8 +1790,7 @@ uint32_t BooleanCircuit::PutVecANDMUXGate(uint32_t a, uint32_t b, uint32_t s) {
 	if (m_eContext == S_BOOL) {
 		sab = PutVectorANDGate(s, ab);
 	} else {
-		uint32_t svec = PutRepeaterGate(s, m_vGates[ab].nvals);
-		sab = PutANDGate(svec, ab);
+		sab = PutANDGate(s, ab);
 	}
 	return PutXORGate(b, sab);
 }

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -708,15 +708,21 @@ inline void BoolSharing::EvaluateConstantGate(uint32_t gateid) {
 	InstantiateGate(gate);
 	value = value * (m_eRole != CLIENT);
 
-	for (uint32_t i = 0; i < ceil_divide(gate->nvals, GATE_T_BITS); i++) {
-		gate->gs.val[i] = value;
-		if(value) {
-			gate->gs.val[i] = ~(0L);
-		}
+	uint32_t valsize = ceil_divide(gate->nvals, GATE_T_BITS);
+	UGATE_T setval;
+	if(value == 1L) {
+		setval = ~(0L);
+	} else {
+		setval = 0L;
 	}
-	if(gate->nvals % GATE_T_BITS != 0) {
-		gate->gs.val[ceil_divide(gate->nvals, GATE_T_BITS)-1] &= ((1L<<(gate->nvals%64)) -1L);
+	for (uint32_t i = 0; i < valsize; ++i) {
+		gate->gs.val[i] = setval;
 	}
+	uint32_t valmod = gate->nvals % GATE_T_BITS;
+	if(valmod != 0) {
+		gate->gs.val[valsize - 1] &= (1L << valmod) - 1L;
+	}
+
 #ifdef DEBUGBOOL
 		std::cout << "Constant gate value: "<< value << std::endl;
 #endif

--- a/src/abycore/sharing/splut.cpp
+++ b/src/abycore/sharing/splut.cpp
@@ -625,8 +625,19 @@ inline void SetupLUT::EvaluateConstantGate(uint32_t gateid) {
 	InstantiateGate(gate);
 	value = value * (m_eRole != CLIENT);
 
-	for (uint32_t i = 0; i < ceil_divide(gate->nvals, GATE_T_BITS); i++) {
-		gate->gs.val[i] = value;
+	uint32_t valsize = ceil_divide(gate->nvals, GATE_T_BITS);
+	UGATE_T setval;
+	if(value == 1L) {
+		setval = ~(0L);
+	} else {
+		setval = 0L;
+	}
+	for (uint32_t i = 0; i < valsize; ++i) {
+		gate->gs.val[i] = setval;
+	}
+	uint32_t valmod = gate->nvals % GATE_T_BITS;
+	if(valmod != 0) {
+		gate->gs.val[valsize - 1] &= (1L << valmod) - 1L;
 	}
 #ifdef DEBUG_SPLUT
 		std::cout << "Constant gate value: "<< value << std::endl;

--- a/src/abycore/sharing/yaoserversharing.cpp
+++ b/src/abycore/sharing/yaoserversharing.cpp
@@ -392,13 +392,7 @@ void YaoServerSharing::PrecomputeGC(std::deque<uint32_t>& queue, ABYSetup* setup
 #endif
 			EvaluateConversionGate(queue[i]);
 		} else if (gate->type == G_CONSTANT) {
-			//assign 0 and 1 gates
-			UGATE_T constval = gate->gs.constval;
-			InstantiateGate(gate);
-			memset(gate->gs.yinput.outKey, 0, m_nSecParamBytes * gate->nvals);
-			for(uint32_t i = 0; i < gate->nvals; i++) {
-				gate->gs.yinput.pi[i] = (constval>>i) & 0x01;
-			}
+			EvaluateConstantGate(gate);
 #ifdef DEBUGYAOSERVER
 			std::cout << "Assigned key to constant gate " << queue[i] << " (" << (uint32_t) gate->gs.yinput.pi[0] << ") : ";
 			PrintKey(gate->gs.yinput.outKey);
@@ -799,6 +793,20 @@ void YaoServerSharing::CollectClientOutputShares() {
 			m_vOutputShareSndBuf.SetBit(m_nOutputShareSndSize, !!((m_vGates[out.front()].gs.val[j / GATE_T_BITS]) & ((UGATE_T) 1 << (j % GATE_T_BITS))));
 		}
 		out.pop_front();
+	}
+}
+
+void YaoServerSharing::EvaluateConstantGate(GATE* gate) {
+	//assign 0 and 1 gates
+	UGATE_T constval = gate->gs.constval;
+	InstantiateGate(gate);
+	memset(gate->gs.yinput.outKey, 0, m_nSecParamBytes * gate->nvals);
+	for (uint32_t i = 0; i < gate->nvals; ++i) {
+		if(constval == 1L) {
+			gate->gs.yinput.pi[i] = 1;
+		} else {
+			gate->gs.yinput.pi[i] = 0;
+		}
 	}
 }
 

--- a/src/abycore/sharing/yaoserversharing.h
+++ b/src/abycore/sharing/yaoserversharing.h
@@ -210,6 +210,12 @@ private:
 	//void EvaluateClientOutputGate(GATE* gate);
 	void CollectClientOutputShares();
 	/**
+	 Method for evaluating a constant gate for the inputted
+	 gate id.
+	 \param gateid	Gate Identifier
+	 */
+	void EvaluateConstantGate(GATE* gate);
+	/**
 	 Method for evaluating Output gate for the inputted
 	 gate object.
 	 \param gate		Gate Object


### PR DESCRIPTION
There are two commits:
The first one is fixing regarding the multiplexer gate implementation which caused issue #79.
The second one is smoothing the constant gate implementation for boolean circuits; that is, now only 0 or 1 is inputted in PutConstantGate. Therefore a bug can be fixed which caused the YAO implementation to be only able to have nvals up to 64 bits.