### PR TITLE
arithmeticcircuits: add missing PutINVGate with argument type share*

### DIFF
--- a/src/abycore/circuit/arithmeticcircuits.cpp
+++ b/src/abycore/circuit/arithmeticcircuits.cpp
@@ -248,6 +248,17 @@ uint32_t ArithmeticCircuit::PutINVGate(uint32_t parentid) {
 	return gateid;
 }
 
+std::vector<uint32_t> ArithmeticCircuit::PutINVGate(std::vector<uint32_t> parentid) {
+	std::vector<uint32_t> out(parentid.size());
+	for (uint32_t i = 0; i < out.size(); i++)
+		out[i] = PutINVGate(parentid[i]);
+	return out;
+}
+
+share* ArithmeticCircuit::PutINVGate(share* parent) {
+	return new arithshare(PutINVGate(parent->get_wires()), this);
+}
+
 uint32_t ArithmeticCircuit::PutCONVGate(std::vector<uint32_t> parentids) {
 	uint32_t gateid = m_cCircuit->PutCONVGate(parentids, 2, S_ARITH, m_nShareBitLen);
 	UpdateInteractiveQueue(gateid);

--- a/src/abycore/circuit/arithmeticcircuits.h
+++ b/src/abycore/circuit/arithmeticcircuits.h
@@ -235,6 +235,8 @@ public:
 
 
 	uint32_t PutINVGate(uint32_t parentid);
+	std::vector<uint32_t> PutINVGate(std::vector<uint32_t> parentid);
+	share* PutINVGate(share* parent);
 	uint32_t PutCONVGate(std::vector<uint32_t> parentids);
 
 	share* PutADDGate(share* ina, share* inb);


### PR DESCRIPTION
Whilst trying to implement stochastic gradient descent with aby I noticed the PutINVGate does not currently accept `share*` types in Arithmetic Circuit.