### PR TITLE
Switch to `Boost::filesystem` from standard C++ filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 
 find_package(GMP REQUIRED)
 find_package(Threads REQUIRED)
-find_package(Boost 1.66.0 REQUIRED COMPONENTS thread system)
+find_package(Boost 1.66.0 REQUIRED COMPONENTS filesystem thread system)
 
 add_subdirectory(src/abycore)
 

--- a/src/abycore/CMakeLists.txt
+++ b/src/abycore/CMakeLists.txt
@@ -28,15 +28,8 @@ target_include_directories(aby
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
 )
 
-# This assumes that libstdc++ is used and should not be required for e.g.
-# libc++.  Linking to libstdc++fs is currently required when using the
-# std::filesystem library.
-# cf. https://gitlab.kitware.com/cmake/cmake/issues/17834
 target_link_libraries(aby
-	PRIVATE stdc++fs
-)
-
-target_link_libraries(aby
+    PRIVATE Boost::filesystem
     PUBLIC OTExtension::otextension
     PUBLIC ENCRYPTO_utils::encrypto_utils
     PUBLIC GMP::GMP

--- a/src/abycore/sharing/boolsharing.cpp
+++ b/src/abycore/sharing/boolsharing.cpp
@@ -19,15 +19,8 @@
 #include "../aby/abysetup.h"
 #include <cstdlib>
 
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace filesystem = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace filesystem = std::experimental::filesystem;
-#else
-#error "C++17 filesystem library not found"
-#endif
+#include <boost/filesystem.hpp>
+namespace filesystem = boost::filesystem;
 
 
 void BoolSharing::Init() {

--- a/src/abycore/sharing/sharing.cpp
+++ b/src/abycore/sharing/sharing.cpp
@@ -23,15 +23,9 @@
 #include <cstring>
 #include <cstdlib>
 
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace filesystem = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace filesystem = std::experimental::filesystem;
-#else
-#error "C++17 filesystem library not found"
-#endif
+#include <boost/system/error_code.hpp>
+#include <boost/filesystem.hpp>
+namespace filesystem = boost::filesystem;
 
 #include <iostream>
 #include <iomanip>
@@ -94,7 +88,7 @@ void Sharing::PreCompFileDelete() {
 		}
 		else {
 			truncation_size = filesystem::file_size(filename) - m_nFilePos;
-			std::error_code ec;
+			boost::system::error_code ec;
 			filesystem::resize_file(filename, truncation_size, ec);
 			if(ec) {
 				std::cout << "Error occured in truncate:" << ec.message() << std::endl;


### PR DESCRIPTION
`Boost::filesystem` is more portable across compilers. This allows ABY to work with Clang on MacOS.

This is similar #112 but uses Boost on all systems. Special casing Apple devices can only create a maintenance nightmare.