### PR TITLE
remove find_dependency(MIRACL) from ABYConfig.cmake.in to fix compilation issues

### DIFF
--- a/cmake/ABYConfig.cmake.in
+++ b/cmake/ABYConfig.cmake.in
@@ -6,7 +6,6 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(OTExtension)
 find_dependency(ENCRYPTO_utils)
-find_dependency(MIRACL)
 find_dependency(GMP)
 find_dependency(Threads)
 


### PR DESCRIPTION
This pull request addresses [Issue #151](https://github.com/encryptogroup/ABY/issues/151), which reports that MIRACL has been replaced by the RELIC library as a dependency in ABY. However, the `find_dependency(MIRACL)` directive was still present in the `ABYConfig.cmake.in` file. This lingering directive could cause errors when compiling projects that use ABY as a library.

This commit removes the `find_dependency(MIRACL)` line from `ABYConfig.cmake.in`, resolving the issue.